### PR TITLE
Add Traefik basic auth to webapp

### DIFF
--- a/docker-compose.deploy.yml
+++ b/docker-compose.deploy.yml
@@ -63,6 +63,8 @@ services:
     restart: unless-stopped
     volumes:
       - pmtiles-data:/public/pmtiles
+    labels:
+      - 'traefik.http.middlewares.mybasicauth.basicauth.users=vcm:$2y$05$U9xfGncXlz8eRkC6itgtOul/aDhTeHz.qBBXk6hss4xyBbT.cpgn6'
 
   worker:
     image: ghcr.io/dataforgoodfr/14_vcmwaterwatch/worker:latest


### PR DESCRIPTION
Adds basic auth middleware via Traefik labels on the webapp service to prevent anonymous access.

Closes #92