### PR TITLE
feat: Add Portuguese municipality (concelho) level to pipeline

### DIFF
--- a/pipelines/extract/download_municipalities.py
+++ b/pipelines/extract/download_municipalities.py
@@ -40,6 +40,61 @@ def convert_gpkg_to_geojson(gpkg_file: Path, output_path: Path):
     return output_path
 
 
+@task(name="dissolve PT concelhos")
+def dissolve_pt_concelhos(
+    municipalities_geojson: Path,
+    concelhos_csv: Path,
+    output_path: Path,
+) -> Path:
+    """Dissolve PT parish geometries into municipality (concelho) polygons."""
+    if output_path.exists():
+        return output_path
+
+    import duckdb
+
+    conn = duckdb.connect()
+    conn.install_extension("spatial")
+    conn.load_extension("spatial")
+
+    conn.sql(f"""
+        CREATE TABLE parishes AS
+        SELECT 
+            NSI_CODE[:4] AS muni_code,
+            geom
+        FROM st_read('{municipalities_geojson}')
+        WHERE CNTR_CODE = 'PT' AND NSI_CODE IS NOT NULL
+    """)
+
+    conn.sql(f"""
+        CREATE TABLE concelhos AS
+        SELECT 
+            CONCAT(cod_distrito, cod_concelho) AS muni_code,
+            nome_concelho
+        FROM read_csv('{concelhos_csv}')
+    """)
+
+    conn.sql("""
+        CREATE TABLE dissolved AS
+        SELECT
+            c.nome_concelho AS COMM_NAME,
+            'PT_CONC_' || p.muni_code AS COMM_ID,
+            'PT' AS CNTR_CODE,
+            ST_Union_Agg(p.geom) AS geom
+        FROM parishes p
+        JOIN concelhos c ON c.muni_code = p.muni_code
+        GROUP BY p.muni_code, c.nome_concelho
+    """)
+
+    conn.sql(f"""
+        COPY (SELECT * FROM dissolved)
+        TO '{output_path}'
+        WITH (FORMAT GDAL, DRIVER 'GeoJSON')
+    """)
+
+    conn.close()
+    return output_path
+
+
 @flow(name="download_municipality")
 def download_municipality(data_directory: Path):
     gpkg = download_commune_gpkg(data_directory / "raw")

--- a/pipelines/extract/download_municipalities.py
+++ b/pipelines/extract/download_municipalities.py
@@ -1,6 +1,6 @@
 """
 Download and convert the commune GPKG file to GeoJSON.
-Produces file data/raw/municipalities.geojson
+Produces files data/raw/municipalities.geojson and data/raw/pt_concelhos_municipalities.geojson
 """
 from pathlib import Path
 from prefect import flow, task
@@ -95,11 +95,28 @@ def dissolve_pt_concelhos(
     return output_path
 
 
+@task(name="download concelhos CSV")
+def download_concelhos_csv(dest_directory: Path) -> Path:
+    dst = dest_directory / "pt_concelhos.csv"
+    if dst.exists():
+        return dst
+    source = "https://raw.githubusercontent.com/centraldedados/codigos_postais/master/data/concelhos.csv"
+    urlretrieve(source, dst)
+    return dst
+
+
 @flow(name="download_municipality")
 def download_municipality(data_directory: Path):
     gpkg = download_commune_gpkg(data_directory / "raw")
     geojson = convert_gpkg_to_geojson(
         gpkg, data_directory / "raw" / "municipalities.geojson"
+    )
+    # PT concelhos (dissolved from parishes)
+    concelhos_csv = download_concelhos_csv(data_directory / "raw")
+    dissolve_pt_concelhos(
+        geojson,
+        concelhos_csv,
+        data_directory / "raw" / "pt_concelhos_municipalities.geojson",
     )
     return geojson
 

--- a/pipelines/extract/tests/test_download_municipalities.py
+++ b/pipelines/extract/tests/test_download_municipalities.py
@@ -1,0 +1,93 @@
+"""Tests for PT municipality dissolve in download_municipalities."""
+import json
+import tempfile
+from pathlib import Path
+
+from pipelines.extract.download_municipalities import dissolve_pt_concelhos
+
+
+def _make_parish_geojson(path: Path):
+    """Create a tiny GeoJSON with 3 parishes in 2 municipalities."""
+    features = [
+        {
+            "type": "Feature",
+            "properties": {
+                "COMM_ID": "PT10105A",
+                "CNTR_CODE": "PT",
+                "COMM_NAME": "Parish A",
+                "NSI_CODE": "010501",
+                "NUTS_CODE": "PT191",
+            },
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [[[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]],
+            },
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "COMM_ID": "PT10105B",
+                "CNTR_CODE": "PT",
+                "COMM_NAME": "Parish B",
+                "NSI_CODE": "010502",
+                "NUTS_CODE": "PT191",
+            },
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [[[1, 0], [2, 0], [2, 1], [1, 1], [1, 0]]],
+            },
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "COMM_ID": "PT10106A",
+                "CNTR_CODE": "PT",
+                "COMM_NAME": "Parish C",
+                "NSI_CODE": "010601",
+                "NUTS_CODE": "PT16D",
+            },
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [[[3, 0], [4, 0], [4, 1], [3, 1], [3, 0]]],
+            },
+        },
+    ]
+    geojson = {"type": "FeatureCollection", "features": features}
+    path.write_text(json.dumps(geojson))
+
+
+def _make_concelhos_csv(path: Path):
+    """Create a concelhos CSV with 2 municipalities."""
+    path.write_text(
+        "cod_distrito,cod_concelho,nome_concelho\n"
+        "01,05,Aveiro\n"
+        "01,06,Castelo de Paiva\n"
+    )
+
+
+def test_dissolve_pt_concelhos():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        geojson_path = tmp / "municipalities.geojson"
+        concelhos_path = tmp / "concelhos.csv"
+        output_path = tmp / "pt_concelhos_municipalities.geojson"
+
+        _make_parish_geojson(geojson_path)
+        _make_concelhos_csv(concelhos_path)
+
+        dissolve_pt_concelhos(geojson_path, concelhos_path, output_path)
+
+        with open(output_path) as f:
+            result = json.load(f)
+
+        features = result["features"]
+        assert len(features) == 2
+
+        by_name = {f["properties"]["COMM_NAME"]: f for f in features}
+        assert "Aveiro" in by_name
+        assert "Castelo de Paiva" in by_name
+
+        aveiro = by_name["Aveiro"]
+        assert aveiro["properties"]["CNTR_CODE"] == "PT"
+        assert aveiro["properties"]["COMM_ID"] == "PT_CONC_0105"
+        assert aveiro["geometry"]["type"] in ("Polygon", "MultiPolygon")


### PR DESCRIPTION
## Summary

Adds 308 Portuguese municipality (concelho) records by dissolving parish-level geometries from the existing Eurostat communes dataset.

## Problem

The municipalities GeoJSON from Eurostat GISCO contains commune-level data. For Portugal this means 3,092 parishes (freguesias) but no municipality entries — so searching for "Aveiro" yields no results.

## Solution

- Download a PT concelhos CSV (308 municipalities with names) from centraldedados
- Dissolve parish geometries by `NSI_CODE[:4]` (distrito + concelho code) using DuckDB spatial
- Output as `pt_concelhos_municipalities.geojson` — automatically picked up by the existing transform glob (`*municipalities.geojson`)
- No changes needed to the transform/load pipeline

## Code changes

- `pipelines/extract/download_municipalities.py`: added `download_concelhos_csv` and `dissolve_pt_concelhos` tasks, wired into flow
- `pipelines/extract/tests/test_download_municipalities.py`: unit test for dissolve logic

## Verified

- 308 municipalities produced with correct properties (`COMM_ID`, `COMM_NAME`, `CNTR_CODE`)
- Aveiro found as `PT_CONC_0105`
- All 72 tests passing