### PR TITLE
feat: add Population to Municipality import + test fixes

### DIFF
--- a/pipelines/extract/download_municipalities.py
+++ b/pipelines/extract/download_municipalities.py
@@ -100,7 +100,8 @@ def add_population_to_communes(
         UPDATE communes
         SET POPULATION = lau."{pop_col}"
         FROM read_csv('{lau_csv}', header=true) AS lau
-        WHERE communes.COMM_ID = lau.GISCO_ID
+        WHERE communes.NSI_CODE = split_part(lau.GISCO_ID, '_', 2)
+          AND communes.CNTR_CODE = lau.CNTR_CODE
     """)
 
 

--- a/pipelines/extract/download_municipalities.py
+++ b/pipelines/extract/download_municipalities.py
@@ -154,10 +154,6 @@ def download_municipality(data_directory: Path):
     municipalities_geojson = raw / "municipalities.geojson"
     pt_concelhos_geojson = raw / "pt_concelhos_municipalities.geojson"
 
-    # Short-circuit if both outputs already exist
-    if municipalities_geojson.exists() and pt_concelhos_geojson.exists():
-        return municipalities_geojson
-
     gpkg = download_commune_gpkg(raw)
     lau_csv, year = download_lau_population(raw)
     concelhos_csv = download_concelhos_csv(raw)

--- a/pipelines/extract/download_municipalities.py
+++ b/pipelines/extract/download_municipalities.py
@@ -3,9 +3,12 @@ Download and convert the commune GPKG file to GeoJSON.
 Produces files data/raw/municipalities.geojson and data/raw/pt_concelhos_municipalities.geojson
 """
 from pathlib import Path
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen, urlretrieve
+
+import duckdb
 from prefect import flow, task
-import pyogrio
-from urllib.request import urlretrieve
+from prefect.cache_policies import NO_CACHE
 
 
 @task(name="download commune gpkg")
@@ -14,85 +17,36 @@ def download_commune_gpkg(dest_directory: Path) -> Path:
     if dst.exists():
         return dst
     source = "https://gisco-services.ec.europa.eu/distribution/v2/communes/gpkg/COMM_RG_01M_2016_3035.gpkg"
-
     urlretrieve(source, dst)
-
     return dst
 
 
-@task(name="convert_gpkg_to_geojson")
-def convert_gpkg_to_geojson(gpkg_file: Path, output_path: Path):
+@task(name="download LAU population CSV")
+def download_lau_population(dest_directory: Path) -> tuple[Path, int]:
+    """Download the latest available LAU population CSV from GISCO.
+
+    Tries candidate years newest-first, HEAD-checks each URL, downloads the
+    first one that exists.  Returns (local_path, year).
     """
-    Convert postal codes in GPKG file to GeoJSON.
-    """
-    if output_path.exists():
-        return output_path
-    gdf = pyogrio.read_dataframe(gpkg_file)
-    gdf = gdf.to_crs(epsg=4326)
+    candidate_years = [2024, 2023, 2022, 2021]
+    base_url = "https://gisco-services.ec.europa.eu/distribution/v2/lau/csv/LAU_RG_01M_{year}_4326.csv"
 
-    # Replace "UK" with "GB" in CNTR_CODE property if it exists
-    if "CNTR_CODE" in gdf.columns:
-        gdf["CNTR_CODE"] = gdf["CNTR_CODE"].replace("UK", "GB")
+    for year in candidate_years:
+        dst = dest_directory / f"lau_population_{year}.csv"
+        if dst.exists():
+            return dst, year
+        url = base_url.format(year=year)
+        try:
+            req = Request(url, method="HEAD")
+            urlopen(req)
+        except (HTTPError, URLError):
+            continue
+        urlretrieve(url, dst)
+        return dst, year
 
-    # Write to GeoJSON using pyogrio
-    pyogrio.write_dataframe(gdf, output_path, driver="GeoJSON")
-
-    return output_path
-
-
-@task(name="dissolve PT concelhos")
-def dissolve_pt_concelhos(
-    municipalities_geojson: Path,
-    concelhos_csv: Path,
-    output_path: Path,
-) -> Path:
-    """Dissolve PT parish geometries into municipality (concelho) polygons."""
-    if output_path.exists():
-        return output_path
-
-    import duckdb
-
-    conn = duckdb.connect()
-    conn.install_extension("spatial")
-    conn.load_extension("spatial")
-
-    conn.sql(f"""
-        CREATE TABLE parishes AS
-        SELECT 
-            NSI_CODE[:4] AS muni_code,
-            geom
-        FROM st_read('{municipalities_geojson}')
-        WHERE CNTR_CODE = 'PT' AND NSI_CODE IS NOT NULL
-    """)
-
-    conn.sql(f"""
-        CREATE TABLE concelhos AS
-        SELECT 
-            CONCAT(cod_distrito, cod_concelho) AS muni_code,
-            nome_concelho
-        FROM read_csv('{concelhos_csv}')
-    """)
-
-    conn.sql("""
-        CREATE TABLE dissolved AS
-        SELECT
-            c.nome_concelho AS COMM_NAME,
-            'PT_CONC_' || p.muni_code AS COMM_ID,
-            'PT' AS CNTR_CODE,
-            ST_Union_Agg(p.geom) AS geom
-        FROM parishes p
-        JOIN concelhos c ON c.muni_code = p.muni_code
-        GROUP BY p.muni_code, c.nome_concelho
-    """)
-
-    conn.sql(f"""
-        COPY (SELECT * FROM dissolved)
-        TO '{output_path}'
-        WITH (FORMAT GDAL, DRIVER 'GeoJSON')
-    """)
-
-    conn.close()
-    return output_path
+    raise RuntimeError(
+        f"Could not find a LAU population CSV for any of years: {candidate_years}"
+    )
 
 
 @task(name="download concelhos CSV")
@@ -105,20 +59,122 @@ def download_concelhos_csv(dest_directory: Path) -> Path:
     return dst
 
 
+@task(name="load communes to DuckDB", cache_policy=NO_CACHE)
+def load_communes_to_duckdb(conn: duckdb.DuckDBPyConnection, gpkg: Path) -> None:
+    """Load communes from GPKG into DuckDB, transforming CRS 3035→4326 and normalising CNTR_CODE."""
+    conn.sql(f"""
+        CREATE TABLE communes AS
+        SELECT
+            * EXCLUDE (geom, CNTR_CODE),
+            ST_Transform(geom, 'EPSG:3035', 'EPSG:4326') AS geom,
+            REPLACE(CNTR_CODE, 'UK', 'GB') AS CNTR_CODE
+        FROM st_read('{gpkg}')
+    """)
+
+
+@task(name="add population to communes", cache_policy=NO_CACHE)
+def add_population_to_communes(
+    conn: duckdb.DuckDBPyConnection, lau_csv: Path, year: int
+) -> None:
+    """Join LAU population data into the communes table.
+
+    Detects the population column name automatically (``POP_<year>`` or ``POP``).
+    """
+    # Detect the population column name from the CSV header
+    desc = conn.sql(
+        f"DESCRIBE SELECT * FROM read_csv('{lau_csv}', header=true) LIMIT 0"
+    )
+    col_names = [row[0] for row in desc.fetchall()]
+
+    pop_col = f"POP_{year}"
+    if pop_col not in col_names:
+        pop_candidates = [c for c in col_names if c.upper().startswith("POP")]
+        if not pop_candidates:
+            raise ValueError(
+                f"No population column found in {lau_csv}. Available columns: {col_names}"
+            )
+        pop_col = pop_candidates[0]
+
+    conn.sql("ALTER TABLE communes ADD COLUMN POPULATION BIGINT")
+    conn.sql(f"""
+        UPDATE communes
+        SET POPULATION = lau."{pop_col}"
+        FROM read_csv('{lau_csv}', header=true) AS lau
+        WHERE communes.COMM_ID = lau.GISCO_ID
+    """)
+
+
+@task(name="dissolve PT concelhos", cache_policy=NO_CACHE)
+def dissolve_pt_concelhos(
+    conn: duckdb.DuckDBPyConnection,
+    concelhos_csv: Path,
+) -> None:
+    """Dissolve PT parish geometries into municipality (concelho) polygons.
+
+    Reads from the ``communes`` table already loaded in *conn* and writes a
+    ``pt_concelhos`` table with dissolved geometries and summed population.
+    """
+    conn.sql(f"""
+        CREATE TABLE pt_concelhos AS
+        SELECT
+            c.nome_concelho AS COMM_NAME,
+            'PT_CONC_' || p.muni_code AS COMM_ID,
+            'PT' AS CNTR_CODE,
+            ST_Union_Agg(p.geom) AS geom,
+            SUM(p.POPULATION)::BIGINT AS POPULATION
+        FROM (
+            SELECT NSI_CODE[:4] AS muni_code, geom, POPULATION
+            FROM communes
+            WHERE CNTR_CODE = 'PT' AND NSI_CODE IS NOT NULL
+        ) p
+        JOIN (
+            SELECT CONCAT(cod_distrito, cod_concelho) AS muni_code, nome_concelho
+            FROM read_csv('{concelhos_csv}')
+        ) c ON c.muni_code = p.muni_code
+        GROUP BY p.muni_code, c.nome_concelho
+    """)
+
+
+@task(name="export GeoJSON", cache_policy=NO_CACHE)
+def export_geojson(
+    conn: duckdb.DuckDBPyConnection, table: str, output_path: Path
+) -> Path:
+    """Export a DuckDB table to a GeoJSON file via the GDAL driver."""
+    conn.sql(f"""
+        COPY (SELECT * FROM {table})
+        TO '{output_path}'
+        WITH (FORMAT GDAL, DRIVER 'GeoJSON')
+    """)
+    return output_path
+
+
 @flow(name="download_municipality")
 def download_municipality(data_directory: Path):
-    gpkg = download_commune_gpkg(data_directory / "raw")
-    geojson = convert_gpkg_to_geojson(
-        gpkg, data_directory / "raw" / "municipalities.geojson"
-    )
-    # PT concelhos (dissolved from parishes)
-    concelhos_csv = download_concelhos_csv(data_directory / "raw")
-    dissolve_pt_concelhos(
-        geojson,
-        concelhos_csv,
-        data_directory / "raw" / "pt_concelhos_municipalities.geojson",
-    )
-    return geojson
+    raw = data_directory / "raw"
+    municipalities_geojson = raw / "municipalities.geojson"
+    pt_concelhos_geojson = raw / "pt_concelhos_municipalities.geojson"
+
+    # Short-circuit if both outputs already exist
+    if municipalities_geojson.exists() and pt_concelhos_geojson.exists():
+        return municipalities_geojson
+
+    gpkg = download_commune_gpkg(raw)
+    lau_csv, year = download_lau_population(raw)
+    concelhos_csv = download_concelhos_csv(raw)
+
+    conn = duckdb.connect()
+    conn.install_extension("spatial")
+    conn.load_extension("spatial")
+    try:
+        load_communes_to_duckdb(conn, gpkg)
+        add_population_to_communes(conn, lau_csv, year)
+        dissolve_pt_concelhos(conn, concelhos_csv)
+        export_geojson(conn, "communes", municipalities_geojson)
+        export_geojson(conn, "pt_concelhos", pt_concelhos_geojson)
+    finally:
+        conn.close()
+
+    return municipalities_geojson
 
 
 if __name__ == "__main__":

--- a/pipelines/extract/tests/test_download_municipalities.py
+++ b/pipelines/extract/tests/test_download_municipalities.py
@@ -1,63 +1,80 @@
-"""Tests for PT municipality dissolve in download_municipalities."""
+"""Tests for download_municipalities pipeline tasks."""
 import json
 import tempfile
 from pathlib import Path
 
-from pipelines.extract.download_municipalities import dissolve_pt_concelhos
+import duckdb
+
+from pipelines.extract.download_municipalities import (
+    add_population_to_communes,
+    dissolve_pt_concelhos,
+    export_geojson,
+)
 
 
-def _make_parish_geojson(path: Path):
-    """Create a tiny GeoJSON with 3 parishes in 2 municipalities."""
-    features = [
-        {
-            "type": "Feature",
-            "properties": {
-                "COMM_ID": "PT10105A",
-                "CNTR_CODE": "PT",
-                "COMM_NAME": "Parish A",
-                "NSI_CODE": "010501",
-                "NUTS_CODE": "PT191",
-            },
-            "geometry": {
-                "type": "Polygon",
-                "coordinates": [[[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]],
-            },
-        },
-        {
-            "type": "Feature",
-            "properties": {
-                "COMM_ID": "PT10105B",
-                "CNTR_CODE": "PT",
-                "COMM_NAME": "Parish B",
-                "NSI_CODE": "010502",
-                "NUTS_CODE": "PT191",
-            },
-            "geometry": {
-                "type": "Polygon",
-                "coordinates": [[[1, 0], [2, 0], [2, 1], [1, 1], [1, 0]]],
-            },
-        },
-        {
-            "type": "Feature",
-            "properties": {
-                "COMM_ID": "PT10106A",
-                "CNTR_CODE": "PT",
-                "COMM_NAME": "Parish C",
-                "NSI_CODE": "010601",
-                "NUTS_CODE": "PT16D",
-            },
-            "geometry": {
-                "type": "Polygon",
-                "coordinates": [[[3, 0], [4, 0], [4, 1], [3, 1], [3, 0]]],
-            },
-        },
-    ]
-    geojson = {"type": "FeatureCollection", "features": features}
-    path.write_text(json.dumps(geojson))
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
 
 
-def _make_concelhos_csv(path: Path):
-    """Create a concelhos CSV with 2 municipalities."""
+def _make_communes_table(conn: duckdb.DuckDBPyConnection, include_population: bool = False) -> None:
+    """Populate a ``communes`` table in *conn* with test data.
+
+    Includes:
+    - 2 PT parishes belonging to 2 different concelhos (for dissolve test)
+    - 1 AT commune (non-PT, to confirm it is not included in PT output)
+
+    Pass ``include_population=True`` to pre-populate the POPULATION column
+    (used by tests that skip the add_population_to_communes step).
+    """
+    if include_population:
+        conn.sql("""
+            CREATE TABLE communes AS
+            SELECT 'AT70701' AS COMM_ID, 'Test AT'  AS COMM_NAME, 'AT' AS CNTR_CODE,
+                   NULL      AS NSI_CODE, NULL AS NUTS_CODE,
+                   ST_GeomFromText('POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))') AS geom,
+                   NULL::BIGINT AS POPULATION
+            UNION ALL
+            SELECT 'PT10105A', 'Parish A', 'PT', '010501', NULL,
+                   ST_GeomFromText('POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))'), NULL::BIGINT
+            UNION ALL
+            SELECT 'PT10105B', 'Parish B', 'PT', '010502', NULL,
+                   ST_GeomFromText('POLYGON((1 0, 2 0, 2 1, 1 1, 1 0))'), NULL::BIGINT
+            UNION ALL
+            SELECT 'PT10106A', 'Parish C', 'PT', '010601', NULL,
+                   ST_GeomFromText('POLYGON((3 0, 4 0, 4 1, 3 1, 3 0))'), NULL::BIGINT
+        """)
+    else:
+        conn.sql("""
+            CREATE TABLE communes AS
+            SELECT 'AT70701' AS COMM_ID, 'Test AT'  AS COMM_NAME, 'AT' AS CNTR_CODE,
+                   NULL      AS NSI_CODE, NULL AS NUTS_CODE,
+                   ST_GeomFromText('POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))') AS geom
+            UNION ALL
+            SELECT 'PT10105A', 'Parish A', 'PT', '010501', NULL,
+                   ST_GeomFromText('POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))')
+            UNION ALL
+            SELECT 'PT10105B', 'Parish B', 'PT', '010502', NULL,
+                   ST_GeomFromText('POLYGON((1 0, 2 0, 2 1, 1 1, 1 0))')
+            UNION ALL
+            SELECT 'PT10106A', 'Parish C', 'PT', '010601', NULL,
+                   ST_GeomFromText('POLYGON((3 0, 4 0, 4 1, 3 1, 3 0))')
+        """)
+
+
+def _make_lau_csv(path: Path, year: int) -> None:
+    """Write a minimal LAU CSV with POP_<year> column."""
+    path.write_text(
+        f"GISCO_ID,LAU_ID,LAU_NAME,POP_{year}\n"
+        f"AT70701,70701,Test AT,12345\n"
+        f"PT10105A,10105A,Parish A,500\n"
+        f"PT10105B,10105B,Parish B,300\n"
+        f"PT10106A,10106A,Parish C,200\n"
+    )
+
+
+def _make_concelhos_csv(path: Path) -> None:
+    """Write a minimal concelhos CSV."""
     path.write_text(
         "cod_distrito,cod_concelho,nome_concelho\n"
         "01,05,Aveiro\n"
@@ -65,17 +82,63 @@ def _make_concelhos_csv(path: Path):
     )
 
 
-def test_dissolve_pt_concelhos():
+def _make_test_conn() -> duckdb.DuckDBPyConnection:
+    """Return an in-memory DuckDB connection with spatial extension loaded."""
+    conn = duckdb.connect()
+    conn.install_extension("spatial")
+    conn.load_extension("spatial")
+    return conn
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_add_population_to_communes():
+    """Population values from the LAU CSV are joined onto the communes table."""
     with tempfile.TemporaryDirectory() as tmpdir:
         tmp = Path(tmpdir)
-        geojson_path = tmp / "municipalities.geojson"
-        concelhos_path = tmp / "concelhos.csv"
+        lau_csv = tmp / "lau_population_2023.csv"
+        year = 2023
+        _make_lau_csv(lau_csv, year)
+
+        conn = _make_test_conn()
+        _make_communes_table(conn)  # no POPULATION column yet
+        add_population_to_communes(conn, lau_csv, year)
+
+        rows = conn.sql("SELECT COMM_ID, POPULATION FROM communes ORDER BY COMM_ID").fetchall()
+        by_id = dict(rows)
+
+        assert by_id["AT70701"] == 12345
+        assert by_id["PT10105A"] == 500
+        assert by_id["PT10105B"] == 300
+        assert by_id["PT10106A"] == 200
+
+        conn.close()
+
+
+def test_dissolve_pt_concelhos():
+    """PT parishes are dissolved into concelhos; POPULATION is summed."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        concelhos_csv = tmp / "concelhos.csv"
         output_path = tmp / "pt_concelhos_municipalities.geojson"
 
-        _make_parish_geojson(geojson_path)
-        _make_concelhos_csv(concelhos_path)
+        _make_concelhos_csv(concelhos_csv)
 
-        dissolve_pt_concelhos(geojson_path, concelhos_path, output_path)
+        conn = _make_test_conn()
+        _make_communes_table(conn, include_population=True)
+
+        # Manually set population values (as add_population_to_communes would)
+        conn.sql("""
+            UPDATE communes SET POPULATION = 500 WHERE COMM_ID = 'PT10105A';
+            UPDATE communes SET POPULATION = 300 WHERE COMM_ID = 'PT10105B';
+            UPDATE communes SET POPULATION = 200 WHERE COMM_ID = 'PT10106A';
+        """)
+
+        dissolve_pt_concelhos(conn, concelhos_csv)
+        export_geojson(conn, "pt_concelhos", output_path)
 
         with open(output_path) as f:
             result = json.load(f)
@@ -91,3 +154,38 @@ def test_dissolve_pt_concelhos():
         assert aveiro["properties"]["CNTR_CODE"] == "PT"
         assert aveiro["properties"]["COMM_ID"] == "PT_CONC_0105"
         assert aveiro["geometry"]["type"] in ("Polygon", "MultiPolygon")
+
+        # Aveiro has parishes A (500) + B (300) = 800
+        assert aveiro["properties"]["POPULATION"] == 800
+
+        castelo = by_name["Castelo de Paiva"]
+        # Castelo de Paiva has parish C (200)
+        assert castelo["properties"]["POPULATION"] == 200
+
+        conn.close()
+
+
+def test_export_geojson():
+    """export_geojson writes a valid GeoJSON FeatureCollection."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        output_path = tmp / "out.geojson"
+
+        conn = _make_test_conn()
+        conn.sql("""
+            CREATE TABLE test_export AS
+            SELECT
+                'X001'  AS COMM_ID,
+                'Test'  AS COMM_NAME,
+                'AT'    AS CNTR_CODE,
+                ST_GeomFromText('POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))') AS geom
+        """)
+        export_geojson(conn, "test_export", output_path)
+
+        assert output_path.exists()
+        with open(output_path) as f:
+            data = json.load(f)
+        assert data["type"] == "FeatureCollection"
+        assert len(data["features"]) == 1
+        assert data["features"][0]["properties"]["COMM_ID"] == "X001"
+        conn.close()

--- a/pipelines/extract/tests/test_download_municipalities.py
+++ b/pipelines/extract/tests/test_download_municipalities.py
@@ -31,7 +31,7 @@ def _make_communes_table(conn: duckdb.DuckDBPyConnection, include_population: bo
         conn.sql("""
             CREATE TABLE communes AS
             SELECT 'AT70701' AS COMM_ID, 'Test AT'  AS COMM_NAME, 'AT' AS CNTR_CODE,
-                   NULL      AS NSI_CODE, NULL AS NUTS_CODE,
+                   '70701'   AS NSI_CODE, NULL AS NUTS_CODE,
                    ST_GeomFromText('POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))') AS geom,
                    NULL::BIGINT AS POPULATION
             UNION ALL
@@ -48,7 +48,7 @@ def _make_communes_table(conn: duckdb.DuckDBPyConnection, include_population: bo
         conn.sql("""
             CREATE TABLE communes AS
             SELECT 'AT70701' AS COMM_ID, 'Test AT'  AS COMM_NAME, 'AT' AS CNTR_CODE,
-                   NULL      AS NSI_CODE, NULL AS NUTS_CODE,
+                   '70701'   AS NSI_CODE, NULL AS NUTS_CODE,
                    ST_GeomFromText('POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))') AS geom
             UNION ALL
             SELECT 'PT10105A', 'Parish A', 'PT', '010501', NULL,
@@ -63,13 +63,17 @@ def _make_communes_table(conn: duckdb.DuckDBPyConnection, include_population: bo
 
 
 def _make_lau_csv(path: Path, year: int) -> None:
-    """Write a minimal LAU CSV with POP_<year> column."""
+    """Write a minimal LAU CSV with POP_<year> column.
+
+    GISCO_ID format is CNTR_CODE_NSI_CODE (e.g. AT_70701),
+    which matches communes via NSI_CODE + CNTR_CODE.
+    """
     path.write_text(
-        f"GISCO_ID,LAU_ID,LAU_NAME,POP_{year}\n"
-        f"AT70701,70701,Test AT,12345\n"
-        f"PT10105A,10105A,Parish A,500\n"
-        f"PT10105B,10105B,Parish B,300\n"
-        f"PT10106A,10106A,Parish C,200\n"
+        f"GISCO_ID,CNTR_CODE,LAU_NAME,POP_{year}\n"
+        f"AT_70701,AT,Test AT,12345\n"
+        f"PT_010501,PT,Parish A,500\n"
+        f"PT_010502,PT,Parish B,300\n"
+        f"PT_010601,PT,Parish C,200\n"
     )
 
 

--- a/pipelines/justfile
+++ b/pipelines/justfile
@@ -69,4 +69,4 @@ export-pmtiles:
   uv run python -m pipelines.export.export_pmtiles
 
 test:
-  uv run pytest
+  uv run python -m pytest

--- a/pipelines/load/load_zones.py
+++ b/pipelines/load/load_zones.py
@@ -188,6 +188,25 @@ def update_geometry_task(records: list[dict], table_name: str) -> None:
     db_helper.update_records(to_update, table_name)
 
 
+@task(name="update_population", cache_policy=NO_CACHE)
+def update_population_task(records: list[dict], table_name: str) -> None:
+    """Update the Population field for existing records in NocoDB.
+
+    Only runs if any record carries a Population value (not all zone types have one).
+    """
+    to_update = [
+        {"Id": r["Id"], "Population": r["Population"]}
+        for r in records
+        if r.get("Id") and r.get("Population") is not None
+    ]
+    if not to_update:
+        return
+    logger = get_run_logger()
+    logger.info(f"Updating population for {len(to_update)} existing records")
+    db_helper = services.db_helper()
+    db_helper.update_records(to_update, table_name)
+
+
 @task(name="lookup_children", cache_policy=INPUTS)
 def lookup_children_task(
     records: list[dict], child_level: str, child_field_name: str
@@ -257,6 +276,9 @@ def load_zones_flow(level: str, data_directory: Path) -> None:
 
     # Update geometry for existing records
     # update_geometry_task(existing_records, level_config.table_name)
+
+    # Update population for existing records (no-op if zone type has no Population)
+    update_population_task(existing_records, level_config.table_name)
 
     # Exclude child link columns from insert — they contain codes, not IDs
     child_field_names = list(level_config.child_level.values()) if level_config.child_level else []

--- a/pipelines/transform/config.py
+++ b/pipelines/transform/config.py
@@ -13,6 +13,7 @@ class LevelConfig:
     title_property: str  # Property name in GeoJSON to map to "Title"
     code_property: str  # Property name in GeoJSON to map to "Code"
     parent_property: str | None = None  # Property name in GeoJSON to map to Parent.Code
+    extra_properties: dict[str, str] | None = None  # GeoJSON property → staging column
 
 
 # Configuration map for each level
@@ -35,6 +36,7 @@ LEVEL_CONFIGS: Dict[str, LevelConfig] = {
         title_property="COMM_NAME",
         code_property="COMM_ID",
         parent_property="CNTR_CODE",
+        extra_properties={"POPULATION": "Population"},
     ),
 }
 

--- a/pipelines/transform/geojson.py
+++ b/pipelines/transform/geojson.py
@@ -38,14 +38,16 @@ def transform_geojson_task(
         if level_config.parent_level:
             parent_code = properties.get(level_config.parent_property)
 
-        rows.append(
-            {
-                "Name": title,
-                "Code": code,
-                "Geometry": json.dumps(geometry),
-                "ParentCode": parent_code,
-            }
-        )
+        row = {
+            "Name": title,
+            "Code": code,
+            "Geometry": json.dumps(geometry),
+            "ParentCode": parent_code,
+        }
+        if level_config.extra_properties:
+            for prop_key, col_name in level_config.extra_properties.items():
+                row[col_name] = properties.get(prop_key)
+        rows.append(row)
 
     return rows
 

--- a/pipelines/worker/test_app.py
+++ b/pipelines/worker/test_app.py
@@ -15,6 +15,30 @@ def client():
 
 
 @pytest.fixture(autouse=True)
+def reset_app_state():
+    """Cancel pending debounce timers and wait for any running flow to finish."""
+    import pipelines.worker.app as app_module
+
+    def _cancel_timers():
+        with app_module._debounce_lock:
+            if app_module._debounce_timer is not None:
+                app_module._debounce_timer.cancel()
+                app_module._debounce_timer = None
+        with app_module._search_debounce_lock:
+            if app_module._search_debounce_timer is not None:
+                app_module._search_debounce_timer.cancel()
+                app_module._search_debounce_timer = None
+
+    _cancel_timers()
+    # Wait for any in-flight flow run to finish before starting the next test
+    acquired = app_module._flow_run_lock.acquire(timeout=10.0)
+    if acquired:
+        app_module._flow_run_lock.release()
+    yield
+    _cancel_timers()
+
+
+@pytest.fixture(autouse=True)
 def zero_debounce():
     """Default to zero debounce so existing tests don't need to wait."""
     import pipelines.worker.app as app_module
@@ -46,7 +70,8 @@ class TestWebhookEndpoint:
         mock_flow.assert_called_once()
 
     def test_webhook_triggers_on_distribution_zone(self, client):
-        with patch("pipelines.worker.app.export_pmtiles_flow") as mock_flow:
+        with patch("pipelines.worker.app.export_pmtiles_flow") as mock_flow, \
+                patch("pipelines.worker.app.build_search_index"):
             mock_flow.return_value = None
             response = client.post(
                 "/webhooks/nocodb",


### PR DESCRIPTION
## Summary

- Adds population data to Municipality import (#99)
- Fixes LAU population join to use NSI_CODE+CNTR_CODE
- Always regenerates output GeoJSONs on pipeline run

## Test fixes

- Mock `build_search_index` in `test_webhook_triggers_on_distribution_zone` — it was missing, causing the real Prefect flow to run and hold `_flow_run_lock`, which blocked subsequent debounce tests
- Add `reset_app_state` autouse fixture to cancel pending debounce timers and wait for `_flow_run_lock` between tests