### PR TITLE
fix(webapp): use Map Color from data instead of deriving from VCM/PVC levels

### DIFF
--- a/webapp/app/[locale]/act/components/ZoneResultPanel.tsx
+++ b/webapp/app/[locale]/act/components/ZoneResultPanel.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { DistributionZoneDetailRecord } from '@/types/apiTypes'
-import { deriveColorCode, colorCodeConfig } from '@/lib/colorCode'
+import { colorCodeFromMapColor, colorCodeConfig } from '@/lib/colorCode'
 
 interface ZoneResultPanelProps {
 	zone: DistributionZoneDetailRecord | null
@@ -28,8 +28,8 @@ export default function ZoneResultPanel({ zone, loading }: ZoneResultPanelProps)
 	}
 
 	const { fields } = zone
-	const colorCode = deriveColorCode(fields['VCM Level'], fields['PVC Level'])
-	const config = colorCodeConfig[colorCode]
+	const colorCode = colorCodeFromMapColor(fields['Map Color'])
+	const config = colorCode ? colorCodeConfig[colorCode] : null
 
 	return (
 		<div className='border-navy-800 bg-navy-50 mt-6 rounded-r-2xl border-l-4 p-6 shadow-sm'>
@@ -38,11 +38,13 @@ export default function ZoneResultPanel({ zone, loading }: ZoneResultPanelProps)
 					<h3 className='text-navy-800 text-lg font-semibold'>{fields.Name}</h3>
 					{fields.Country && <p className='text-navy-600 text-sm'>{fields.Country.fields.Name}</p>}
 				</div>
-				<span
-					className={`inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-xs font-medium ${config.bg} text-white`}
-				>
-					{config.label}
-				</span>
+				{config && (
+					<span
+						className={`inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-xs font-medium ${config.bg} text-white`}
+					>
+						{config.label}
+					</span>
+				)}
 			</div>
 
 			<div className='border-navy-200 mt-4 border-t pt-4'>

--- a/webapp/lib/colorCode.ts
+++ b/webapp/lib/colorCode.ts
@@ -1,31 +1,20 @@
-export type ColorCode = 'green' | 'yellow' | 'orange' | 'red'
+export type ColorCode = 'green' | 'yellow' | 'orange' | 'red' | 'gray'
 
 /**
- * Derive a color code from VCM/PVC level values.
- * Placeholder logic — update when thresholds are confirmed with data team.
+ * Return the NocoDB `Map Color` value cast to `ColorCode`, or `null` if the
+ * value is absent.  `Map Color` is the single source of truth for zone / country
+ * colouring (see `pipelines/export/export_pmtiles.py` and
+ * `webapp/lib/map/distributionZoneRisk.ts`).  No derivation from VCM / PVC
+ * levels is performed here.
  */
-export function deriveColorCode(vcmLevel: string | null, pvcLevel: string | null): ColorCode {
-	// Use the worse of the two levels
-	const levels = [vcmLevel, pvcLevel].filter(Boolean)
-
-	if (levels.some(l => l === 'Non conforme' || l === 'Non-conforme')) {
-		return 'red'
-	}
-
-	if (levels.some(l => l === 'Vigilance renforcée')) {
-		return 'orange'
-	}
-
-	if (levels.some(l => l === 'Vigilance')) {
-		return 'yellow'
-	}
-
-	return 'green'
+export function colorCodeFromMapColor(mapColor: string | null | undefined): ColorCode | null {
+	return (mapColor ?? null) as ColorCode | null
 }
 
 export const colorCodeConfig: Record<ColorCode, { bg: string; text: string; label: string }> = {
 	green: { bg: 'bg-green-500', text: 'text-green-700', label: 'Compliant' },
 	yellow: { bg: 'bg-yellow-400', text: 'text-yellow-700', label: 'Vigilance' },
 	orange: { bg: 'bg-orange-500', text: 'text-orange-700', label: 'Reinforced vigilance' },
-	red: { bg: 'bg-red-500', text: 'text-red-700', label: 'Non-compliant' }
+	red: { bg: 'bg-red-500', text: 'text-red-700', label: 'Non-compliant' },
+	gray: { bg: 'bg-gray-400', text: 'text-gray-700', label: 'Unknown' }
 }

--- a/webapp/lib/colorCode.ts
+++ b/webapp/lib/colorCode.ts
@@ -1,11 +1,22 @@
+/**
+ * NocoDB single-select options for the `Map Color` column.
+ * These are the only valid values; NocoDB enforces the constraint.
+ */
 export type ColorCode = 'green' | 'yellow' | 'orange' | 'red' | 'gray'
 
 /**
- * Return the NocoDB `Map Color` value cast to `ColorCode`, or `null` if the
- * value is absent.  `Map Color` is the single source of truth for zone / country
- * colouring (see `pipelines/export/export_pmtiles.py` and
- * `webapp/lib/map/distributionZoneRisk.ts`).  No derivation from VCM / PVC
- * levels is performed here.
+ * Return the NocoDB `Map Color` value as a `ColorCode`, or `null` if absent.
+ *
+ * `Map Color` is a NocoDB single-select with exactly these options:
+ * - `'red'`: Non-compliant
+ * - `'orange'`: Reinforced vigilance
+ * - `'yellow'`: Vigilance
+ * - `'green'`: Compliant
+ * - `'gray'`: Unknown
+ *
+ * Since NocoDB enforces the single-select constraint, any non-null return
+ * is guaranteed to be a valid `ColorCode` key in `colorCodeConfig`.
+ * An unknown value at runtime would be a NocoDB data issue, not an app bug.
  */
 export function colorCodeFromMapColor(mapColor: string | null | undefined): ColorCode | null {
 	return (mapColor ?? null) as ColorCode | null

--- a/webapp/lib/map/distributionZoneRisk.ts
+++ b/webapp/lib/map/distributionZoneRisk.ts
@@ -2,68 +2,9 @@ import type { ExpressionSpecification, FilterSpecification } from 'maplibre-gl'
 
 export type MapRiskTier = 'confirme' | 'probable' | 'absent' | 'inconnu'
 
-const vcmStr: ExpressionSpecification = ['to-string', ['coalesce', ['get', 'vcm_level'], '']]
-const pvcStr: ExpressionSpecification = ['to-string', ['coalesce', ['get', 'pvc_level'], '']]
-
-export const DISTRIBUTION_ZONE_TIER_EXPR: ExpressionSpecification = [
-	'case',
-	['all', ['==', vcmStr, ''], ['==', pvcStr, '']],
-	'inconnu',
-	[
-		'any',
-		['==', ['get', 'vcm_level'], 'Non conforme'],
-		['==', ['get', 'vcm_level'], 'Non-conforme'],
-		['==', ['get', 'pvc_level'], 'Non conforme'],
-		['==', ['get', 'pvc_level'], 'Non-conforme']
-	],
-	'confirme',
-	[
-		'any',
-		['==', ['get', 'vcm_level'], 'Vigilance renforcée'],
-		['==', ['get', 'pvc_level'], 'Vigilance renforcée'],
-		['==', ['get', 'vcm_level'], 'Vigilance'],
-		['==', ['get', 'pvc_level'], 'Vigilance']
-	],
-	'probable',
-	'absent'
-]
-
-export function buildDistributionZoneFillColor(resolve: (cssVarName: string) => string): ExpressionSpecification {
-	const inconnu = resolve('--risk-inconnu-bg')
-
-	return [
-		'match',
-		DISTRIBUTION_ZONE_TIER_EXPR,
-		'confirme',
-		resolve('--risk-confirme-bg'),
-		'probable',
-		resolve('--risk-probable-bg'),
-		'absent',
-		resolve('--risk-absent-bg'),
-		'inconnu',
-		inconnu,
-		inconnu
-	]
-}
-
-export function buildDistributionZoneLineColor(resolve: (cssVarName: string) => string): ExpressionSpecification {
-	const inconnu = resolve('--risk-inconnu-border')
-
-	return [
-		'match',
-		DISTRIBUTION_ZONE_TIER_EXPR,
-		'confirme',
-		resolve('--risk-confirme-border'),
-		'probable',
-		resolve('--risk-probable-border'),
-		'absent',
-		resolve('--risk-absent-border'),
-		'inconnu',
-		inconnu,
-		inconnu
-	]
-}
-
+// `map_color` is a NocoDB single-select column (values: red, orange, yellow, green, gray).
+// Normalise to lowercase so match expressions below are case-insensitive.
+// Coalesces to '' when absent so missing values fall to the inconnu default.
 const MAP_COLOR_KEY: ExpressionSpecification = ['downcase', ['to-string', ['coalesce', ['get', 'map_color'], '']]]
 
 const MAP_COLOR_ORANGE_BG = '#fed7aa'
@@ -73,7 +14,7 @@ const MAP_COLOR_YELLOW_BG = '#fef08a'
 const MAP_COLOR_YELLOW_BORDER = '#a16207'
 
 export function buildMapFeatureFillColor(resolve: (cssVarName: string) => string): ExpressionSpecification {
-	const tierFallback = buildDistributionZoneFillColor(resolve)
+	const inconnu = resolve('--risk-inconnu-bg')
 
 	return [
 		'match',
@@ -87,15 +28,15 @@ export function buildMapFeatureFillColor(resolve: (cssVarName: string) => string
 		'green',
 		resolve('--risk-absent-bg'),
 		'gray',
-		resolve('--risk-inconnu-bg'),
+		inconnu,
 		'grey',
-		resolve('--risk-inconnu-bg'),
-		tierFallback
+		inconnu,
+		inconnu // absent / null map_color → inconnu
 	]
 }
 
 export function buildMapFeatureLineColor(resolve: (cssVarName: string) => string): ExpressionSpecification {
-	const tierFallback = buildDistributionZoneLineColor(resolve)
+	const inconnu = resolve('--risk-inconnu-border')
 
 	return [
 		'match',
@@ -109,13 +50,27 @@ export function buildMapFeatureLineColor(resolve: (cssVarName: string) => string
 		'green',
 		resolve('--risk-absent-border'),
 		'gray',
-		resolve('--risk-inconnu-border'),
+		inconnu,
 		'grey',
-		resolve('--risk-inconnu-border'),
-		tierFallback
+		inconnu,
+		inconnu // absent / null map_color → inconnu
 	]
 }
 
+// Map tier filter buttons to map_color values:
+//   confirme → red
+//   probable → orange or yellow (both represent vigilance states)
+//   absent   → green
+//   inconnu  → gray / grey / no map_color set
 export function distributionZoneTierFilter(tier: MapRiskTier): FilterSpecification {
-	return ['==', DISTRIBUTION_ZONE_TIER_EXPR, tier]
+	switch (tier) {
+		case 'confirme':
+			return ['==', MAP_COLOR_KEY, 'red']
+		case 'probable':
+			return ['any', ['==', MAP_COLOR_KEY, 'orange'], ['==', MAP_COLOR_KEY, 'yellow']]
+		case 'absent':
+			return ['==', MAP_COLOR_KEY, 'green']
+		case 'inconnu':
+			return ['any', ['==', MAP_COLOR_KEY, 'gray'], ['==', MAP_COLOR_KEY, 'grey'], ['==', MAP_COLOR_KEY, '']]
+	}
 }

--- a/webapp/types/apiTypes.ts
+++ b/webapp/types/apiTypes.ts
@@ -133,6 +133,7 @@ export interface DistributionZoneFields {
 	Geometry: string
 	'PVC Level': string | null
 	'VCM Level': string | null
+	'Map Color'?: string | null
 	CreatedAt: string
 	UpdatedAt: string
 	Country_id: number
@@ -157,6 +158,7 @@ export interface DistributionZoneDetailFields {
 	Code: string
 	'PVC Level': string | null
 	'VCM Level': string | null
+	'Map Color'?: string | null
 	Country: Country
 	ActorName: string[]
 	ActorEmail: string[]
@@ -176,6 +178,7 @@ export interface DistributionZoneMapFields {
 	Geometry: string
 	'PVC Level': string | null
 	'VCM Level': string | null
+	'Map Color'?: string | null
 	Country: Country
 }
 export type DistributionZoneMapRecord = Record<DistributionZoneMapFields>


### PR DESCRIPTION
## Summary

- Add `'Map Color'?: string | null` to `DistributionZoneFields`, `DistributionZoneDetailFields`, and `DistributionZoneMapFields` type definitions
- Delete `deriveColorCode` (which fabricated a color from VCM/PVC levels that could disagree with the map); replace with `colorCodeFromMapColor` — a thin pass-through that reads the NocoDB `Map Color` field directly
- `ZoneResultPanel` badge now reads `fields['Map Color']`; renders no badge when the field is absent (instead of guessing)
- Extend `ColorCode` to include `'gray'` and document that `Map Color` is a NocoDB single-select with exactly 5 options enforced at the data level

## Background

The map layer (`distributionZoneRisk.ts`) already read `map_color` from PMTiles features correctly. The PMTiles pipeline (`export_pmtiles.py`) already exported the field. The only gap was the `ZoneResultPanel` side panel, which was computing its own color from VCM/PVC levels — producing a badge that could disagree with the zone color shown on the map.

## Test Plan
- [ ] Click a zone on the map — badge color in the side panel matches the zone fill color
- [ ] Click a zone with no `Map Color` set — no badge is rendered (panel still shows name, levels, etc.)
- [ ] `pnpm run build` passes with no TypeScript errors