### PR TITLE
#54 | Resources page with methodology section

### DIFF
--- a/webapp/app/[locale]/resources/components/CtaBanner.tsx
+++ b/webapp/app/[locale]/resources/components/CtaBanner.tsx
@@ -1,0 +1,34 @@
+import Link from 'next/link'
+
+import { ArrowUpRight } from 'lucide-react'
+
+import { Button } from '@/components/ui/button'
+
+interface CtaBannerProps {
+	title: string
+	subtitle: string
+	buttonLabel: string
+	href: string
+}
+
+export default function CtaBanner({ title, subtitle, buttonLabel, href }: CtaBannerProps) {
+	return (
+		<div className='bg-navy-900 flex flex-col items-start justify-between gap-4 rounded-xl px-6 py-6 sm:flex-row sm:items-center'>
+			<div>
+				<p className='font-[lexend] text-base font-semibold text-white'>{title}</p>
+				<p className='mt-1 text-sm text-white/70'>{subtitle}</p>
+			</div>
+			<Button
+				asChild
+				variant='outlinePrimary'
+				size='xl'
+				className='shrink-0 border-white text-white hover:bg-white hover:text-navy-900'
+			>
+				<Link href={href} className='text-[15px]'>
+					{buttonLabel}
+					<ArrowUpRight className='transition-transform group-hover:translate-x-1 group-hover:-translate-y-1' />
+				</Link>
+			</Button>
+		</div>
+	)
+}

--- a/webapp/app/[locale]/resources/components/MethodologySection.tsx
+++ b/webapp/app/[locale]/resources/components/MethodologySection.tsx
@@ -59,7 +59,8 @@ const CVM_TABLE_ROWS = [
 	}
 ]
 
-export function MethodologySection() {
+// TODO: i18n — INFO_CARDS and CVM_TABLE_ROWS are hardcoded in English; extract for translation when i18n is added
+export default function MethodologySection() {
 	return (
 		<div>
 			{/* Section header */}
@@ -92,14 +93,14 @@ export function MethodologySection() {
 			{/* CVM Reference Table */}
 			<div className='mb-10'>
 				<h3 className='text-navy-800 mb-4 font-[lexend] text-lg font-semibold'>CVM Risk Level Reference Table</h3>
-				<div className='border-navy-200 overflow-hidden rounded-xl border'>
+				<div className='border-navy-200 overflow-x-auto rounded-xl border'>
 					<table className='w-full text-sm'>
 						<thead>
 							<tr className='bg-navy-800 text-left text-white'>
-								<th className='px-4 py-3 font-semibold'>Risk level</th>
-								<th className='px-4 py-3 font-semibold'>VCM concentration</th>
-								<th className='px-4 py-3 font-semibold'>Pipe age</th>
-								<th className='px-4 py-3 font-semibold'>Infrastructure type</th>
+								<th scope='col' className='px-4 py-3 font-semibold'>Risk level</th>
+								<th scope='col' className='px-4 py-3 font-semibold'>VCM concentration</th>
+								<th scope='col' className='px-4 py-3 font-semibold'>Pipe age</th>
+								<th scope='col' className='px-4 py-3 font-semibold'>Infrastructure type</th>
 							</tr>
 						</thead>
 						<tbody>
@@ -137,7 +138,7 @@ export function MethodologySection() {
 						asChild
 						variant='outlinePrimary'
 						size='xl'
-						className='shrink-0 border-white text-white hover:text-navy-900'
+						className='shrink-0 border-white text-white hover:bg-white hover:text-navy-900'
 					>
 						<Link href='/act#involved' className='text-[15px]'>
 							Get in touch

--- a/webapp/app/[locale]/resources/components/MethodologySection.tsx
+++ b/webapp/app/[locale]/resources/components/MethodologySection.tsx
@@ -1,61 +1,79 @@
 import Link from 'next/link'
 
-import { ArrowUpRight, BookOpen, Database, FlaskConical, Users } from 'lucide-react'
+import { ArrowUpRight } from 'lucide-react'
 
 import { Button } from '@/components/ui/button'
 
+// Each card uses a simple styled span (circle + text character) instead of a lucide icon.
+// This matches the design mockup which shows minimal circle icons.
 const INFO_CARDS = [
 	{
-		icon: FlaskConical,
-		title: 'Data collection methodology',
-		body: 'Water quality data is gathered from official national databases, citizen-submitted reports, and partner research institutions. All entries are timestamped and linked to a source reference.'
+		iconChar: 'ℹ',
+		iconBg: 'bg-blue-100',
+		iconColor: 'text-blue-700',
+		title: 'Data Sources',
+		body: 'Data comes from three sources: (1) official reports from national health authorities, (2) citizen contributions verified by our team, (3) peer-reviewed scientific publications.'
 	},
 	{
-		icon: Database,
-		title: 'Risk level classification',
-		body: 'Contamination risk is scored using the CVM Reference Table below, combining measured VCM concentration, pipe age, and infrastructure type to produce a four-tier risk level.'
+		iconChar: '✓',
+		iconBg: 'bg-green-100',
+		iconColor: 'text-green-700',
+		title: 'Verification Process',
+		body: 'Each citizen contribution goes through validation: verification of the source document, cross-referencing with official data, and validation by at least one member of the scientific team.'
 	},
 	{
-		icon: BookOpen,
-		title: 'Scientific references',
-		body: 'Our thresholds and health guidance align with the WHO Guidelines for Drinking-water Quality and EU Directive 2020/2184 on water intended for human consumption.'
+		iconChar: '?',
+		iconBg: 'bg-amber-100',
+		iconColor: 'text-amber-700',
+		title: 'Interpreting Thresholds',
+		body: 'CVM concentrations are expressed in µg/L. The European directive sets a threshold of 0.5 µg/L. Some countries apply stricter standards. See the table below.'
 	},
 	{
-		icon: Users,
-		title: 'Community contributions',
-		body: 'Citizen-submitted data is reviewed by volunteer water specialists before it is published. Unverified contributions are flagged with a "pending review" status on the map.'
+		iconChar: '!',
+		iconBg: 'bg-red-100',
+		iconColor: 'text-red-700',
+		title: 'Limitations & Precautions',
+		body: 'Map data does not replace official analysis. When in doubt, contact your local health authority. VCM Watch is a citizen awareness tool.'
 	}
 ]
 
-// CVM Reference Table rows: [level, concentration, pipe age, infrastructure type]
+// CVM Concentration Reference Table — columns match design:
+// Concentration (µg/L) | Level | Interpretation | Recommended Action
 const CVM_TABLE_ROWS = [
 	{
-		level: 'Low',
-		levelColor: 'bg-green-100 text-green-800',
-		concentration: '< 0.5 µg/L',
-		pipeAge: '< 20 years',
-		infrastructure: 'Modern PVC or non-PVC'
+		concentration: '< 0.1',
+		level: 'Compliant (strict)',
+		dotColor: 'bg-green-500',
+		interpretation: 'Below detection threshold',
+		action: 'No action required'
 	},
 	{
-		level: 'Moderate',
-		levelColor: 'bg-yellow-100 text-yellow-800',
-		concentration: '0.5 – 2 µg/L',
-		pipeAge: '20 – 35 years',
-		infrastructure: 'Older PVC, maintained'
+		concentration: '0.1 – 0.5',
+		level: 'Compliant',
+		dotColor: 'bg-green-400',
+		interpretation: 'EU Directive 2020/2184 met',
+		action: 'Routine monitoring'
 	},
 	{
-		level: 'High',
-		levelColor: 'bg-orange-100 text-orange-800',
-		concentration: '2 – 5 µg/L',
-		pipeAge: '35 – 50 years',
-		infrastructure: 'Ageing PVC 70s/80s network'
+		concentration: '0.5 – 1.0',
+		level: 'Vigilance',
+		dotColor: 'bg-orange-400',
+		interpretation: 'Above EU threshold',
+		action: 'Report to health authority'
 	},
 	{
-		level: 'Critical',
-		levelColor: 'bg-red-100 text-red-800',
-		concentration: '> 5 µg/L',
-		pipeAge: '> 50 years',
-		infrastructure: 'Pre-1975 PVC, degraded'
+		concentration: '> 1.0',
+		level: 'Alert',
+		dotColor: 'bg-red-500',
+		interpretation: 'Significant exceedance',
+		action: 'Contact ARS urgently'
+	},
+	{
+		concentration: 'Not measured',
+		level: 'Unknown',
+		dotColor: 'bg-gray-400',
+		interpretation: 'Data unavailable',
+		action: 'Request local analysis'
 	}
 ]
 
@@ -67,60 +85,59 @@ export default function MethodologySection() {
 			<div className='mb-8'>
 				<h2 className='text-navy-800 font-[lexend] text-2xl font-semibold'>Methodology</h2>
 				<p className='text-navy-600 mt-2 max-w-2xl text-base'>
-					How we collect, validate, and classify VCM contamination data — and how you can contribute.
+					How to interpret the data and who to contact to act correctly.
 				</p>
 			</div>
 
 			{/* 2×2 info cards */}
 			<div className='mb-10 grid grid-cols-1 gap-5 sm:grid-cols-2'>
-				{INFO_CARDS.map(card => {
-					const Icon = card.icon
-
-					return (
-						<div key={card.title} className='border-navy-200 bg-navy-50 rounded-xl border p-5'>
-							<div className='mb-3 flex items-center gap-3'>
-								<div className='bg-navy-800 flex h-9 w-9 shrink-0 items-center justify-center rounded-lg text-white'>
-									<Icon className='h-5 w-5' />
-								</div>
-								<h3 className='text-navy-800 font-[lexend] text-base font-semibold'>{card.title}</h3>
-							</div>
-							<p className='text-navy-600 text-sm leading-relaxed'>{card.body}</p>
+				{INFO_CARDS.map(card => (
+					<div key={card.title} className='border-navy-200 bg-navy-50 rounded-xl border p-5'>
+						<div className='mb-3 flex items-center gap-3'>
+							<span
+								className={`flex h-9 w-9 shrink-0 items-center justify-center rounded-full text-base font-bold ${card.iconBg} ${card.iconColor}`}
+							>
+								{card.iconChar}
+							</span>
+							<h3 className='text-navy-800 font-[lexend] text-base font-semibold'>{card.title}</h3>
 						</div>
-					)
-				})}
+						<p className='text-navy-600 text-sm leading-relaxed'>{card.body}</p>
+					</div>
+				))}
 			</div>
 
-			{/* CVM Reference Table */}
+			{/* CVM Concentration Reference Table */}
 			<div className='mb-10'>
-				<h3 className='text-navy-800 mb-4 font-[lexend] text-lg font-semibold'>CVM Risk Level Reference Table</h3>
+				<h3 className='text-navy-800 mb-4 font-[lexend] text-lg font-semibold'>CVM Concentration Reference Table</h3>
 				<div className='border-navy-200 overflow-x-auto rounded-xl border'>
 					<table className='w-full text-sm'>
 						<thead>
 							<tr className='bg-navy-800 text-left text-white'>
-								<th scope='col' className='px-4 py-3 font-semibold'>Risk level</th>
-								<th scope='col' className='px-4 py-3 font-semibold'>VCM concentration</th>
-								<th scope='col' className='px-4 py-3 font-semibold'>Pipe age</th>
-								<th scope='col' className='px-4 py-3 font-semibold'>Infrastructure type</th>
+								<th scope='col' className='px-4 py-3 font-semibold'>Concentration (µg/L)</th>
+								<th scope='col' className='px-4 py-3 font-semibold'>Level</th>
+								<th scope='col' className='px-4 py-3 font-semibold'>Interpretation</th>
+								<th scope='col' className='px-4 py-3 font-semibold'>Recommended Action</th>
 							</tr>
 						</thead>
 						<tbody>
 							{CVM_TABLE_ROWS.map((row, i) => (
 								<tr key={row.level} className={i % 2 === 0 ? 'bg-white' : 'bg-navy-50'}>
+									<td className='text-navy-700 px-4 py-3 font-mono text-xs'>{row.concentration}</td>
 									<td className='px-4 py-3'>
-										<span className={`inline-block rounded-full px-2.5 py-0.5 text-xs font-semibold ${row.levelColor}`}>
-											{row.level}
+										<span className='flex items-center gap-1.5'>
+											<span className={`inline-block h-2.5 w-2.5 rounded-full ${row.dotColor}`} />
+											<span className='text-navy-700'>{row.level}</span>
 										</span>
 									</td>
-									<td className='text-navy-700 px-4 py-3 font-mono text-xs'>{row.concentration}</td>
-									<td className='text-navy-700 px-4 py-3'>{row.pipeAge}</td>
-									<td className='text-navy-700 px-4 py-3'>{row.infrastructure}</td>
+									<td className='text-navy-700 px-4 py-3'>{row.interpretation}</td>
+									<td className='text-navy-700 px-4 py-3'>{row.action}</td>
 								</tr>
 							))}
 						</tbody>
 					</table>
 				</div>
 				<p className='text-navy-500 mt-2 text-xs'>
-					* Thresholds are indicative and based on WHO/EU guidance. Site-specific factors may alter the final classification.
+					* Thresholds based on WHO guidelines and EU Directive 2020/2184. Site-specific factors may affect the final classification.
 				</p>
 			</div>
 

--- a/webapp/app/[locale]/resources/components/MethodologySection.tsx
+++ b/webapp/app/[locale]/resources/components/MethodologySection.tsx
@@ -1,0 +1,151 @@
+import Link from 'next/link'
+
+import { ArrowUpRight, BookOpen, Database, FlaskConical, Users } from 'lucide-react'
+
+import { Button } from '@/components/ui/button'
+
+const INFO_CARDS = [
+	{
+		icon: FlaskConical,
+		title: 'Data collection methodology',
+		body: 'Water quality data is gathered from official national databases, citizen-submitted reports, and partner research institutions. All entries are timestamped and linked to a source reference.'
+	},
+	{
+		icon: Database,
+		title: 'Risk level classification',
+		body: 'Contamination risk is scored using the CVM Reference Table below, combining measured VCM concentration, pipe age, and infrastructure type to produce a four-tier risk level.'
+	},
+	{
+		icon: BookOpen,
+		title: 'Scientific references',
+		body: 'Our thresholds and health guidance align with the WHO Guidelines for Drinking-water Quality and EU Directive 2020/2184 on water intended for human consumption.'
+	},
+	{
+		icon: Users,
+		title: 'Community contributions',
+		body: 'Citizen-submitted data is reviewed by volunteer water specialists before it is published. Unverified contributions are flagged with a "pending review" status on the map.'
+	}
+]
+
+// CVM Reference Table rows: [level, concentration, pipe age, infrastructure type]
+const CVM_TABLE_ROWS = [
+	{
+		level: 'Low',
+		levelColor: 'bg-green-100 text-green-800',
+		concentration: '< 0.5 µg/L',
+		pipeAge: '< 20 years',
+		infrastructure: 'Modern PVC or non-PVC'
+	},
+	{
+		level: 'Moderate',
+		levelColor: 'bg-yellow-100 text-yellow-800',
+		concentration: '0.5 – 2 µg/L',
+		pipeAge: '20 – 35 years',
+		infrastructure: 'Older PVC, maintained'
+	},
+	{
+		level: 'High',
+		levelColor: 'bg-orange-100 text-orange-800',
+		concentration: '2 – 5 µg/L',
+		pipeAge: '35 – 50 years',
+		infrastructure: 'Ageing PVC 70s/80s network'
+	},
+	{
+		level: 'Critical',
+		levelColor: 'bg-red-100 text-red-800',
+		concentration: '> 5 µg/L',
+		pipeAge: '> 50 years',
+		infrastructure: 'Pre-1975 PVC, degraded'
+	}
+]
+
+export function MethodologySection() {
+	return (
+		<div>
+			{/* Section header */}
+			<div className='mb-8'>
+				<h2 className='text-navy-800 font-[lexend] text-2xl font-semibold'>Methodology</h2>
+				<p className='text-navy-600 mt-2 max-w-2xl text-base'>
+					How we collect, validate, and classify VCM contamination data — and how you can contribute.
+				</p>
+			</div>
+
+			{/* 2×2 info cards */}
+			<div className='mb-10 grid grid-cols-1 gap-5 sm:grid-cols-2'>
+				{INFO_CARDS.map(card => {
+					const Icon = card.icon
+
+					return (
+						<div key={card.title} className='border-navy-200 bg-navy-50 rounded-xl border p-5'>
+							<div className='mb-3 flex items-center gap-3'>
+								<div className='bg-navy-800 flex h-9 w-9 shrink-0 items-center justify-center rounded-lg text-white'>
+									<Icon className='h-5 w-5' />
+								</div>
+								<h3 className='text-navy-800 font-[lexend] text-base font-semibold'>{card.title}</h3>
+							</div>
+							<p className='text-navy-600 text-sm leading-relaxed'>{card.body}</p>
+						</div>
+					)
+				})}
+			</div>
+
+			{/* CVM Reference Table */}
+			<div className='mb-10'>
+				<h3 className='text-navy-800 mb-4 font-[lexend] text-lg font-semibold'>CVM Risk Level Reference Table</h3>
+				<div className='border-navy-200 overflow-hidden rounded-xl border'>
+					<table className='w-full text-sm'>
+						<thead>
+							<tr className='bg-navy-800 text-left text-white'>
+								<th className='px-4 py-3 font-semibold'>Risk level</th>
+								<th className='px-4 py-3 font-semibold'>VCM concentration</th>
+								<th className='px-4 py-3 font-semibold'>Pipe age</th>
+								<th className='px-4 py-3 font-semibold'>Infrastructure type</th>
+							</tr>
+						</thead>
+						<tbody>
+							{CVM_TABLE_ROWS.map((row, i) => (
+								<tr key={row.level} className={i % 2 === 0 ? 'bg-white' : 'bg-navy-50'}>
+									<td className='px-4 py-3'>
+										<span className={`inline-block rounded-full px-2.5 py-0.5 text-xs font-semibold ${row.levelColor}`}>
+											{row.level}
+										</span>
+									</td>
+									<td className='text-navy-700 px-4 py-3 font-mono text-xs'>{row.concentration}</td>
+									<td className='text-navy-700 px-4 py-3'>{row.pipeAge}</td>
+									<td className='text-navy-700 px-4 py-3'>{row.infrastructure}</td>
+								</tr>
+							))}
+						</tbody>
+					</table>
+				</div>
+				<p className='text-navy-500 mt-2 text-xs'>
+					* Thresholds are indicative and based on WHO/EU guidance. Site-specific factors may alter the final classification.
+				</p>
+			</div>
+
+			{/* Who to contact CTA */}
+			<div>
+				<h3 className='text-navy-800 mb-4 font-[lexend] text-lg font-semibold'>Who to contact?</h3>
+				<div className='bg-navy-900 flex flex-col items-start justify-between gap-4 rounded-xl px-6 py-6 sm:flex-row sm:items-center'>
+					<div>
+						<p className='font-[lexend] text-base font-semibold text-white'>Questions about the methodology?</p>
+						<p className='mt-1 text-sm text-white/70'>
+							Reach out to our scientific team or join the open-source project to propose improvements.
+						</p>
+					</div>
+					<Button
+						asChild
+						variant='outlinePrimary'
+						size='xl'
+						className='shrink-0 border-white text-white hover:text-navy-900'
+					>
+						<Link href='/act#involved' className='text-[15px]'>
+							Get in touch
+							<ArrowUpRight className='transition-transform group-hover:translate-x-1 group-hover:-translate-y-1' />
+						</Link>
+					</Button>
+				</div>
+			</div>
+		</div>
+	)
+}

--- a/webapp/app/[locale]/resources/components/MethodologySection.tsx
+++ b/webapp/app/[locale]/resources/components/MethodologySection.tsx
@@ -1,8 +1,4 @@
-import Link from 'next/link'
-
-import { ArrowUpRight } from 'lucide-react'
-
-import { Button } from '@/components/ui/button'
+import CtaBanner from './CtaBanner'
 
 // Each card uses a simple styled span (circle + text character) instead of a lucide icon.
 // This matches the design mockup which shows minimal circle icons.
@@ -144,25 +140,12 @@ export default function MethodologySection() {
 			{/* Who to contact CTA */}
 			<div>
 				<h3 className='text-navy-800 mb-4 font-[lexend] text-lg font-semibold'>Who to contact?</h3>
-				<div className='bg-navy-900 flex flex-col items-start justify-between gap-4 rounded-xl px-6 py-6 sm:flex-row sm:items-center'>
-					<div>
-						<p className='font-[lexend] text-base font-semibold text-white'>Questions about the methodology?</p>
-						<p className='mt-1 text-sm text-white/70'>
-							Reach out to our scientific team or join the open-source project to propose improvements.
-						</p>
-					</div>
-					<Button
-						asChild
-						variant='outlinePrimary'
-						size='xl'
-						className='shrink-0 border-white text-white hover:bg-white hover:text-navy-900'
-					>
-						<Link href='/act#involved' className='text-[15px]'>
-							Get in touch
-							<ArrowUpRight className='transition-transform group-hover:translate-x-1 group-hover:-translate-y-1' />
-						</Link>
-					</Button>
-				</div>
+				<CtaBanner
+					title='Questions about the methodology?'
+					subtitle='Reach out to our scientific team or join the open-source project to propose improvements.'
+					buttonLabel='Get in touch'
+					href='/act#involved'
+				/>
 			</div>
 		</div>
 	)

--- a/webapp/app/[locale]/resources/components/ResourceCard.tsx
+++ b/webapp/app/[locale]/resources/components/ResourceCard.tsx
@@ -1,0 +1,68 @@
+import Link from 'next/link'
+
+import { ArrowUpRight } from 'lucide-react'
+
+export type ResourceType = 'guide' | 'report' | 'template' | 'factsheet' | 'video'
+
+export interface ResourceCardProps {
+	type: ResourceType
+	title: string
+	description: string
+	actionLabel: string
+	actionUrl: string
+}
+
+const TYPE_CONFIG: Record<ResourceType, { label: string; className: string }> = {
+	guide: {
+		label: 'Guide',
+		className: 'bg-green-100 text-green-800 border-green-200'
+	},
+	report: {
+		label: 'Report',
+		className: 'bg-blue-100 text-blue-800 border-blue-200'
+	},
+	template: {
+		label: 'Template',
+		className: 'bg-orange-100 text-orange-800 border-orange-200'
+	},
+	factsheet: {
+		label: 'Fact sheet',
+		className: 'bg-teal-100 text-teal-800 border-teal-200'
+	},
+	video: {
+		label: 'Video',
+		className: 'bg-red-100 text-red-800 border-red-200'
+	}
+}
+
+export function ResourceCard({ type, title, description, actionLabel, actionUrl }: ResourceCardProps) {
+	const config = TYPE_CONFIG[type]
+
+	return (
+		<div className='border-navy-200 bg-navy-50 flex h-full flex-col rounded-xl border p-5'>
+			{/* Tag badge */}
+			<div className='mb-3'>
+				<span className={`inline-block rounded-full border px-2.5 py-0.5 text-xs font-semibold ${config.className}`}>
+					{config.label}
+				</span>
+			</div>
+
+			{/* Title */}
+			<h3 className='text-navy-800 mb-2 font-[lexend] text-base font-semibold leading-snug'>{title}</h3>
+
+			{/* Description */}
+			<p className='text-navy-600 mb-4 flex-1 text-sm leading-relaxed'>{description}</p>
+
+			{/* Action link */}
+			<div className='mt-auto flex justify-end'>
+				<Link
+					href={actionUrl}
+					className='text-navy-700 hover:text-navy-900 inline-flex items-center gap-1 text-sm font-medium underline-offset-2 hover:underline'
+				>
+					{actionLabel}
+					<ArrowUpRight className='h-4 w-4' />
+				</Link>
+			</div>
+		</div>
+	)
+}

--- a/webapp/app/[locale]/resources/components/ResourceCard.tsx
+++ b/webapp/app/[locale]/resources/components/ResourceCard.tsx
@@ -35,7 +35,9 @@ const TYPE_CONFIG: Record<ResourceType, { label: string; className: string }> = 
 	}
 }
 
-export function ResourceCard({ type, title, description, actionLabel, actionUrl }: ResourceCardProps) {
+// TODO: when real URLs are used, add an `external` boolean prop (or detect via URL) to apply
+// target="_blank" rel="noopener noreferrer" on external links.
+export default function ResourceCard({ type, title, description, actionLabel, actionUrl }: ResourceCardProps) {
 	const config = TYPE_CONFIG[type]
 
 	return (

--- a/webapp/app/[locale]/resources/components/ResourceTabNav.tsx
+++ b/webapp/app/[locale]/resources/components/ResourceTabNav.tsx
@@ -53,7 +53,7 @@ export default function ResourceTabNav() {
 	}, [])
 
 	return (
-		<nav className='border-navy-200 bg-navy-50/80 sticky top-[84px] z-10 border-b backdrop-blur-sm'>
+		<nav className='border-navy-200 bg-navy-50/80 sticky top-[64px] lg:top-[84px] z-10 border-b backdrop-blur-sm'>
 			<div className='flex gap-1 px-1 py-1'>
 				{TABS.map(tab => (
 					<Link

--- a/webapp/app/[locale]/resources/components/ResourceTabNav.tsx
+++ b/webapp/app/[locale]/resources/components/ResourceTabNav.tsx
@@ -13,7 +13,7 @@ const TABS = [
 
 type TabId = (typeof TABS)[number]['id']
 
-export function ResourceTabNav() {
+export default function ResourceTabNav() {
 	const [activeTab, setActiveTab] = useState<TabId>('resources')
 
 	useEffect(() => {
@@ -53,13 +53,14 @@ export function ResourceTabNav() {
 	}, [])
 
 	return (
-		<nav className='border-navy-200 bg-navy-50/80 sticky top-0 z-10 border-b backdrop-blur-sm'>
+		<nav className='border-navy-200 bg-navy-50/80 sticky top-[84px] z-10 border-b backdrop-blur-sm'>
 			<div className='flex gap-1 px-1 py-1'>
 				{TABS.map(tab => (
 					<Link
 						key={tab.id}
 						href={`#${tab.id}`}
 						onClick={() => setActiveTab(tab.id)}
+						aria-current={activeTab === tab.id ? 'true' : undefined}
 						className={cn(
 							'font-[lexend] rounded-lg px-5 py-2 text-sm font-medium transition-colors',
 							activeTab === tab.id

--- a/webapp/app/[locale]/resources/components/ResourceTabNav.tsx
+++ b/webapp/app/[locale]/resources/components/ResourceTabNav.tsx
@@ -1,0 +1,76 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+import Link from 'next/link'
+
+import { cn } from '@/lib/utils'
+
+const TABS = [
+	{ id: 'resources', label: 'Resources' },
+	{ id: 'methodology', label: 'Methodology' }
+] as const
+
+type TabId = (typeof TABS)[number]['id']
+
+export function ResourceTabNav() {
+	const [activeTab, setActiveTab] = useState<TabId>('resources')
+
+	useEffect(() => {
+		const observers: IntersectionObserver[] = []
+
+		// Track which sections are intersecting and pick the topmost one
+		const intersecting = new Set<TabId>()
+
+		TABS.forEach(({ id }) => {
+			const el = document.getElementById(id)
+			if (!el) return
+
+			const observer = new IntersectionObserver(
+				([entry]) => {
+					if (entry.isIntersecting) {
+						intersecting.add(id)
+					} else {
+						intersecting.delete(id)
+					}
+
+					// Set active to the first tab whose section is visible
+					const firstVisible = TABS.find(t => intersecting.has(t.id))
+					if (firstVisible) {
+						setActiveTab(firstVisible.id)
+					}
+				},
+				{ rootMargin: '-20% 0px -60% 0px', threshold: 0 }
+			)
+
+			observer.observe(el)
+			observers.push(observer)
+		})
+
+		return () => {
+			observers.forEach(o => o.disconnect())
+		}
+	}, [])
+
+	return (
+		<nav className='border-navy-200 bg-navy-50/80 sticky top-0 z-10 border-b backdrop-blur-sm'>
+			<div className='flex gap-1 px-1 py-1'>
+				{TABS.map(tab => (
+					<Link
+						key={tab.id}
+						href={`#${tab.id}`}
+						onClick={() => setActiveTab(tab.id)}
+						className={cn(
+							'font-[lexend] rounded-lg px-5 py-2 text-sm font-medium transition-colors',
+							activeTab === tab.id
+								? 'bg-navy-800 text-white'
+								: 'text-navy-600 hover:bg-navy-100 hover:text-navy-800'
+						)}
+					>
+						{tab.label}
+					</Link>
+				))}
+			</div>
+		</nav>
+	)
+}

--- a/webapp/app/[locale]/resources/components/ResourcesSection.tsx
+++ b/webapp/app/[locale]/resources/components/ResourcesSection.tsx
@@ -1,0 +1,96 @@
+import Link from 'next/link'
+
+import { ArrowUpRight } from 'lucide-react'
+
+import { Button } from '@/components/ui/button'
+
+import { ResourceCard, type ResourceCardProps } from './ResourceCard'
+
+const MOCK_RESOURCES: ResourceCardProps[] = [
+	{
+		type: 'guide',
+		title: 'Citizen Guide to Water Quality Testing',
+		description:
+			'A step-by-step guide for residents who want to collect water samples and understand laboratory results related to VCM contamination.',
+		actionLabel: 'Read guide',
+		actionUrl: '#'
+	},
+	{
+		type: 'report',
+		title: 'European PVC Pipe Infrastructure Report 2023',
+		description:
+			'An overview of PVC water distribution pipes installed across Europe in the 1970s–80s, with maps of known contamination hotspots.',
+		actionLabel: 'View report',
+		actionUrl: '#'
+	},
+	{
+		type: 'guide',
+		title: 'How to Request Water Quality Data from Authorities',
+		description:
+			'Know your rights. This guide explains the legal frameworks in EU countries that entitle citizens to access official water quality records.',
+		actionLabel: 'Read guide',
+		actionUrl: '#'
+	},
+	{
+		type: 'template',
+		title: 'Letter Template: Request to Water Provider',
+		description:
+			'A ready-to-use letter template to formally request VCM contamination data from your local water utility or municipal authority.',
+		actionLabel: 'Download template',
+		actionUrl: '#'
+	},
+	{
+		type: 'factsheet',
+		title: 'VCM Health Risks – Key Facts',
+		description:
+			'A concise fact sheet summarising the established health risks associated with vinyl chloride monomer (VCM) exposure through drinking water.',
+		actionLabel: 'View fact sheet',
+		actionUrl: '#'
+	},
+	{
+		type: 'video',
+		title: 'Understanding PVC Pipe Degradation (Webinar)',
+		description:
+			'A recorded webinar by water chemistry experts explaining how PVC pipes degrade over time and how VCM can leach into drinking water.',
+		actionLabel: 'Watch video',
+		actionUrl: '#'
+	}
+]
+
+export function ResourcesSection() {
+	return (
+		<div>
+			{/* Section header */}
+			<div className='mb-8'>
+				<h2 className='text-navy-800 font-[lexend] text-2xl font-semibold'>Resources</h2>
+				<p className='text-navy-600 mt-2 max-w-2xl text-base'>
+					Guides, reports, templates, and other materials to help citizens, researchers, and advocates understand and act on
+					VCM water contamination.
+				</p>
+			</div>
+
+			{/* 3-column grid */}
+			<div className='grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3'>
+				{MOCK_RESOURCES.map((resource, i) => (
+					<ResourceCard key={i} {...resource} />
+				))}
+			</div>
+
+			{/* CTA banner */}
+			<div className='bg-navy-900 mt-10 flex flex-col items-start justify-between gap-4 rounded-xl px-6 py-6 sm:flex-row sm:items-center'>
+				<div>
+					<p className='font-[lexend] text-lg font-semibold text-white'>Have a resource to share?</p>
+					<p className='mt-1 text-sm text-white/70'>
+						Help the community grow by submitting a guide, report, or any relevant material.
+					</p>
+				</div>
+				<Button asChild variant='outlinePrimary' size='xl' className='shrink-0 border-white text-white hover:text-navy-900'>
+					<Link href='/act#involved' className='text-[15px]'>
+						Contact us
+						<ArrowUpRight className='transition-transform group-hover:translate-x-1 group-hover:-translate-y-1' />
+					</Link>
+				</Button>
+			</div>
+		</div>
+	)
+}

--- a/webapp/app/[locale]/resources/components/ResourcesSection.tsx
+++ b/webapp/app/[locale]/resources/components/ResourcesSection.tsx
@@ -1,13 +1,13 @@
-import Link from 'next/link'
-
-import { ArrowUpRight } from 'lucide-react'
-
-import { Button } from '@/components/ui/button'
-
 import ResourceCard, { type ResourceCardProps } from './ResourceCard'
+import CtaBanner from './CtaBanner'
 
-const MOCK_RESOURCES: ResourceCardProps[] = [
+interface MockResource extends ResourceCardProps {
+	id: string
+}
+
+const MOCK_RESOURCES: MockResource[] = [
 	{
+		id: 'citizen-guide-water-quality',
 		type: 'guide',
 		title: 'Citizen Guide to Water Quality Testing',
 		description:
@@ -16,6 +16,7 @@ const MOCK_RESOURCES: ResourceCardProps[] = [
 		actionUrl: '#'
 	},
 	{
+		id: 'european-pvc-pipe-report-2023',
 		type: 'report',
 		title: 'European PVC Pipe Infrastructure Report 2023',
 		description:
@@ -24,6 +25,7 @@ const MOCK_RESOURCES: ResourceCardProps[] = [
 		actionUrl: '#'
 	},
 	{
+		id: 'request-water-quality-data',
 		type: 'guide',
 		title: 'How to Request Water Quality Data from Authorities',
 		description:
@@ -32,6 +34,7 @@ const MOCK_RESOURCES: ResourceCardProps[] = [
 		actionUrl: '#'
 	},
 	{
+		id: 'letter-template-water-provider',
 		type: 'template',
 		title: 'Letter Template: Request to Water Provider',
 		description:
@@ -40,6 +43,7 @@ const MOCK_RESOURCES: ResourceCardProps[] = [
 		actionUrl: '#'
 	},
 	{
+		id: 'vcm-health-risks-factsheet',
 		type: 'factsheet',
 		title: 'VCM Health Risks – Key Facts',
 		description:
@@ -48,6 +52,7 @@ const MOCK_RESOURCES: ResourceCardProps[] = [
 		actionUrl: '#'
 	},
 	{
+		id: 'pvc-pipe-degradation-webinar',
 		type: 'video',
 		title: 'Understanding PVC Pipe Degradation (Webinar)',
 		description:
@@ -73,24 +78,18 @@ export default function ResourcesSection() {
 			{/* 3-column grid */}
 			<div className='grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3'>
 				{MOCK_RESOURCES.map(resource => (
-					<ResourceCard key={resource.title} {...resource} />
+					<ResourceCard key={resource.id} {...resource} />
 				))}
 			</div>
 
 			{/* CTA banner */}
-			<div className='bg-navy-900 mt-10 flex flex-col items-start justify-between gap-4 rounded-xl px-6 py-6 sm:flex-row sm:items-center'>
-				<div>
-					<p className='font-[lexend] text-lg font-semibold text-white'>Have a resource to share?</p>
-					<p className='mt-1 text-sm text-white/70'>
-						Help the community grow by submitting a guide, report, or any relevant material.
-					</p>
-				</div>
-				<Button asChild variant='outlinePrimary' size='xl' className='shrink-0 border-white text-white hover:bg-white hover:text-navy-900'>
-					<Link href='/act#involved' className='text-[15px]'>
-						Contact us
-						<ArrowUpRight className='transition-transform group-hover:translate-x-1 group-hover:-translate-y-1' />
-					</Link>
-				</Button>
+			<div className='mt-10'>
+				<CtaBanner
+					title='Have a resource to share?'
+					subtitle='Help the community grow by submitting a guide, report, or any relevant material.'
+					buttonLabel='Contact us'
+					href='/act#involved'
+				/>
 			</div>
 		</div>
 	)

--- a/webapp/app/[locale]/resources/components/ResourcesSection.tsx
+++ b/webapp/app/[locale]/resources/components/ResourcesSection.tsx
@@ -4,7 +4,7 @@ import { ArrowUpRight } from 'lucide-react'
 
 import { Button } from '@/components/ui/button'
 
-import { ResourceCard, type ResourceCardProps } from './ResourceCard'
+import ResourceCard, { type ResourceCardProps } from './ResourceCard'
 
 const MOCK_RESOURCES: ResourceCardProps[] = [
 	{
@@ -57,7 +57,8 @@ const MOCK_RESOURCES: ResourceCardProps[] = [
 	}
 ]
 
-export function ResourcesSection() {
+// TODO: i18n — MOCK_RESOURCES is hardcoded in English; extract for translation when i18n is added
+export default function ResourcesSection() {
 	return (
 		<div>
 			{/* Section header */}
@@ -71,8 +72,8 @@ export function ResourcesSection() {
 
 			{/* 3-column grid */}
 			<div className='grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3'>
-				{MOCK_RESOURCES.map((resource, i) => (
-					<ResourceCard key={i} {...resource} />
+				{MOCK_RESOURCES.map(resource => (
+					<ResourceCard key={resource.title} {...resource} />
 				))}
 			</div>
 
@@ -84,7 +85,7 @@ export function ResourcesSection() {
 						Help the community grow by submitting a guide, report, or any relevant material.
 					</p>
 				</div>
-				<Button asChild variant='outlinePrimary' size='xl' className='shrink-0 border-white text-white hover:text-navy-900'>
+				<Button asChild variant='outlinePrimary' size='xl' className='shrink-0 border-white text-white hover:bg-white hover:text-navy-900'>
 					<Link href='/act#involved' className='text-[15px]'>
 						Contact us
 						<ArrowUpRight className='transition-transform group-hover:translate-x-1 group-hover:-translate-y-1' />

--- a/webapp/app/[locale]/resources/page.tsx
+++ b/webapp/app/[locale]/resources/page.tsx
@@ -23,14 +23,14 @@ export default function ResourcesPage() {
 			{/* Sections */}
 			<div className='mt-12 space-y-16'>
 				{/* Resources section */}
-				<section id='resources'>
+				<section id='resources' className='scroll-mt-[148px]'>
 					<ResourcesSection />
 				</section>
 
 				<hr className='border-navy-200' />
 
 				{/* Methodology section */}
-				<section id='methodology'>
+				<section id='methodology' className='scroll-mt-[148px]'>
 					<MethodologySection />
 				</section>
 			</div>

--- a/webapp/app/[locale]/resources/page.tsx
+++ b/webapp/app/[locale]/resources/page.tsx
@@ -1,8 +1,39 @@
+import { SectionSeparator } from '@/components/SectionSeparator'
+
+import { MethodologySection } from './components/MethodologySection'
+import { ResourcesSection } from './components/ResourcesSection'
+import { ResourceTabNav } from './components/ResourceTabNav'
+
 export default function ResourcesPage() {
 	return (
-		<main className='mx-auto w-full max-w-5xl px-6 py-16'>
-			<h1 className='text-3xl font-semibold text-gray-900'>Resources</h1>
-			<p className='mt-4 text-lg text-gray-600'>This page is under construction.</p>
+		<main className='container mx-auto px-4 py-16 md:px-8'>
+			{/* Page header */}
+			<div>
+				<h1 className='text-navy-800 font-[lexend] text-3xl font-semibold'>Resources</h1>
+				<div className='mt-6'>
+					<SectionSeparator />
+				</div>
+			</div>
+
+			{/* Sticky tab navigation */}
+			<div className='mt-6'>
+				<ResourceTabNav />
+			</div>
+
+			{/* Sections */}
+			<div className='mt-10 space-y-16'>
+				{/* Resources section */}
+				<section id='resources'>
+					<ResourcesSection />
+				</section>
+
+				<hr className='border-navy-200' />
+
+				{/* Methodology section */}
+				<section id='methodology'>
+					<MethodologySection />
+				</section>
+			</div>
 		</main>
 	)
 }

--- a/webapp/app/[locale]/resources/page.tsx
+++ b/webapp/app/[locale]/resources/page.tsx
@@ -1,8 +1,8 @@
 import { SectionSeparator } from '@/components/SectionSeparator'
 
-import { MethodologySection } from './components/MethodologySection'
-import { ResourcesSection } from './components/ResourcesSection'
-import { ResourceTabNav } from './components/ResourceTabNav'
+import MethodologySection from './components/MethodologySection'
+import ResourcesSection from './components/ResourcesSection'
+import ResourceTabNav from './components/ResourceTabNav'
 
 export default function ResourcesPage() {
 	return (
@@ -21,7 +21,7 @@ export default function ResourcesPage() {
 			</div>
 
 			{/* Sections */}
-			<div className='mt-10 space-y-16'>
+			<div className='mt-12 space-y-16'>
 				{/* Resources section */}
 				<section id='resources'>
 					<ResourcesSection />


### PR DESCRIPTION
## Summary

Implements the Resources page with two sections accessible via sticky anchor-based tab navigation.

### Resources Section
- 3-column grid of resource cards (6 mock resources: guides, report, template, factsheet, video)
- Colored type badges per resource type
- CTA banner to contact/share resources

### Methodology Section
- 2×2 info cards: Data Sources, Verification Process, Interpreting Thresholds, Limitations & Precautions
- CVM Concentration Reference Table (5 rows matching EU directive thresholds)
- Contact CTA banner

### Other
- Sticky tab nav with IntersectionObserver-based active state
- Responsive sticky offset (64px mobile / 84px desktop)
- Scroll margins for anchor navigation
- Shared `CtaBanner` component extracted for reuse
- TODO comments for future i18n

Closes #54