### PR TITLE
feat: implement About page (#55)

### DIFF
--- a/webapp/app/[locale]/about/page.tsx
+++ b/webapp/app/[locale]/about/page.tsx
@@ -1,8 +1,138 @@
-export default function AboutPage() {
+import Link from 'next/link'
+
+import { ArrowUpRight } from 'lucide-react'
+
+import { Button } from '@/components/ui/button'
+import { InfoCard } from '@/components/InfoCard'
+import { SectionSeparator } from '@/components/SectionSeparator'
+import { TeamCard } from '@/components/TeamCard'
+import { getT } from '@/i18n/server'
+import type { Locale } from '@/i18n/i18next.config'
+
+interface TeamMember {
+	id: string
+	initials: string
+	name: string
+	role: string
+	color: 'teal' | 'green' | 'purple' | 'navy'
+}
+
+const teams: { labelKey: string; members: TeamMember[] }[] = [
+	{
+		labelKey: 'about-team-product',
+		members: [
+			{
+				id: 'ml-prod',
+				initials: 'ML',
+				name: 'Marie Laurent',
+				role: 'Scientific Director\nHydrogeology, CNRS',
+				color: 'teal'
+			},
+			{
+				id: 'kd-prod',
+				initials: 'KD',
+				name: 'Karim Diouf',
+				role: 'Lead Developer\nData & Cartography',
+				color: 'green'
+			},
+			{
+				id: 'sv-prod',
+				initials: 'SV',
+				name: 'Sofia Vasquez',
+				role: 'Network Coordinator\nAssociation Relations',
+				color: 'purple'
+			},
+			{ id: 'tm-prod', initials: 'TM', name: 'Thomas Müller', role: 'Policy Analyst\nEU Regulation', color: 'navy' }
+		]
+	},
+	{
+		labelKey: 'about-team-legal',
+		members: [
+			{
+				id: 'ml-legal',
+				initials: 'ML',
+				name: 'Marie Laurent',
+				role: 'Scientific Director\nHydrogeology, CNRS',
+				color: 'teal'
+			},
+			{
+				id: 'kd-legal',
+				initials: 'KD',
+				name: 'Karim Diouf',
+				role: 'Lead Developer\nData & Cartography',
+				color: 'green'
+			},
+			{
+				id: 'sv-legal',
+				initials: 'SV',
+				name: 'Sofia Vasquez',
+				role: 'Network Coordinator\nAssociation Relations',
+				color: 'purple'
+			},
+			{ id: 'tm-legal', initials: 'TM', name: 'Thomas Müller', role: 'Policy Analyst\nEU Regulation', color: 'navy' }
+		]
+	}
+]
+
+export default async function AboutPage({ params }: { params: Promise<{ locale: string }> }) {
+	const { locale } = await params
+	const { t } = await getT('default', { locale: locale as Locale })
+
 	return (
-		<main className='mx-auto w-full max-w-5xl px-6 py-16'>
-			<h1 className='text-3xl font-semibold text-gray-900'>About</h1>
-			<p className='mt-4 text-lg text-gray-600'>This page is under construction.</p>
+		<main className='flex min-h-screen flex-col'>
+			{/* Header */}
+			<div className='container mx-auto px-4 pt-16 md:px-8'>
+				<h1 className='text-navy-800 font-[lexend] text-3xl font-semibold'>{t('about-title')}</h1>
+				<p className='text-navy-600 mt-2 text-lg'>{t('about-subtitle')}</p>
+				<div className='mt-6'>
+					<SectionSeparator />
+				</div>
+			</div>
+
+			{/* Description Card */}
+			<section className='container mx-auto px-4 py-12 md:px-8'>
+				<InfoCard>
+					<div className='flex flex-col gap-4'>
+						<p className='text-navy-800 text-base leading-relaxed'>{t('about-description-p1')}</p>
+						<p className='text-navy-800 text-base leading-relaxed'>{t('about-description-p2')}</p>
+						<p className='text-navy-800 text-base leading-relaxed'>{t('about-description-p3')}</p>
+					</div>
+				</InfoCard>
+			</section>
+
+			{/* Team Section */}
+			<section className='container mx-auto px-4 pb-12 md:px-8'>
+				<h2 className='text-navy-800 font-[lexend] text-2xl font-semibold'>{t('about-team-title')}</h2>
+
+				{teams.map((team, idx) => (
+					<div key={team.labelKey} className={idx === 0 ? 'mt-8' : 'mt-10'}>
+						<h3 className='text-navy-800 mb-4 font-[lexend] text-base font-semibold'>{t(team.labelKey)}</h3>
+						<div className='grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4'>
+							{team.members.map(member => (
+								<TeamCard key={member.id} {...member} />
+							))}
+						</div>
+					</div>
+				))}
+			</section>
+
+			{/* Join CTA */}
+			<section className='container mx-auto px-4 pb-16 md:px-8'>
+				<div className='bg-navy-50 flex flex-col items-start justify-between gap-6 rounded-2xl border border-gray-200 px-8 py-6 sm:flex-row sm:items-center'>
+					<div>
+						<h3 className='text-navy-800 font-[lexend] text-lg font-semibold'>{t('about-join-title')}</h3>
+						<p className='text-navy-600 mt-1 text-base'>{t('about-join-description')}</p>
+					</div>
+					<Button
+						asChild
+						className='bg-aqua-600 hover:bg-aqua-700 shrink-0 rounded-xl px-6 py-3 font-semibold text-white'
+					>
+						<Link href='mailto:contact@vcm-watch.eu'>
+							{t('about-join-cta')} <ArrowUpRight className='ml-1 size-4' />
+						</Link>
+					</Button>
+				</div>
+			</section>
 		</main>
 	)
 }

--- a/webapp/components/Footer.tsx
+++ b/webapp/components/Footer.tsx
@@ -32,7 +32,7 @@ export const Footer = ({
 		title: 'VCM Water Watch',
 		url: ROUTES.HOME
 	},
-	description = 'water-watch@contact.com',
+	description = 'contact@vcm-watch.eu',
 	menuItems = [
 		{
 			links: [
@@ -66,7 +66,9 @@ export const Footer = ({
 									/>
 								</Link>
 							</div>
-							<p className='mt-4 font-bold'>{description}</p>
+							<a href={`mailto:${description}`} className='hover:text-aqua-200 mt-4 block font-bold'>
+								{description}
+							</a>
 						</div>
 						{menuItems.map((section, sectionIdx) => (
 							<div key={sectionIdx}>

--- a/webapp/components/TeamCard.tsx
+++ b/webapp/components/TeamCard.tsx
@@ -1,0 +1,27 @@
+interface TeamCardProps {
+	initials: string
+	name: string
+	role: string
+	color: 'teal' | 'green' | 'purple' | 'navy'
+}
+
+const colorMap = {
+	teal: 'bg-aqua-600',
+	green: 'bg-emerald-600',
+	purple: 'bg-purple-600',
+	navy: 'bg-navy-600'
+}
+
+export const TeamCard = ({ initials, name, role, color }: TeamCardProps) => {
+	return (
+		<div className='flex flex-col items-center gap-3 rounded-2xl border border-gray-200 bg-white px-6 py-8'>
+			<div
+				className={`flex h-16 w-16 items-center justify-center rounded-full text-lg font-bold text-white ${colorMap[color]}`}
+			>
+				{initials}
+			</div>
+			<p className='text-navy-800 font-[lexend] text-base font-semibold'>{name}</p>
+			<p className='text-navy-600 whitespace-pre-line text-center text-sm leading-snug'>{role}</p>
+		</div>
+	)
+}

--- a/webapp/i18n/en/default.json
+++ b/webapp/i18n/en/default.json
@@ -1,6 +1,17 @@
 {
-  "blog-list": "Blog list",
-  "blog-resources": "Resources",
-  "blog-get-info": "Get info about VCM water pollution, news, articles, and more.",
-  "blog-read-more": "Read More"
+	"blog-list": "Blog list",
+	"blog-resources": "Resources",
+	"blog-get-info": "Get info about VCM water pollution, news, articles, and more.",
+	"blog-read-more": "Read More",
+	"about-title": "About the project",
+	"about-subtitle": "Values, team, and progress — to build trust and inform.",
+	"about-description-p1": "VCM Watch is an information platform about the presence of vinyl chloride monomer (VCM), a carcinogenic gas, in European drinking water networks. VCM migrates from PVC pipes installed before 1980 into tap water. In France, systematic testing introduced in 2012 has revealed exceedances of the European regulatory limits in more than 5,000 municipalities. However, very little data is available at the European level, as testing is not currently mandatory, even though a maximum threshold of 0.5 µg/L was established by the European Union in 1998.",
+	"about-description-p2": "To address this gap, VCM Watch compiles all available information on potentially contaminated water infrastructure in order to produce a Europe-wide risk map. The data is collected from national authorities in the countries concerned, or directly from water suppliers. It can also be submitted by users. Historical archives from PVC manufacturers have also been used to identify risks at the national level.",
+	"about-description-p3": "The goal is to identify areas where enhanced monitoring is needed and to make this information available to both citizens and public decision-makers, while also initiating a large-scale data collection effort to further complete the proposed risk map. The project is led by the Earth Chair at the University of Angers, which revealed the extent of VCM contamination in France by making public analyses conducted by health authorities that had never previously been disclosed. The platform was developed by volunteers from the Data for Good association, who structured the database, designed the map, and built the website. It was also enriched by an investigation carried out jointly with the European Investigative Collaborations network of journalists. Finally, it benefited from contributions by many volunteer citizens who shared locally conducted analyses and identified relevant reports to help build the database.",
+	"about-team-title": "The Team",
+	"about-team-product": "Product Team",
+	"about-team-legal": "Legal Team",
+	"about-join-title": "Want to join VCM Watch?",
+	"about-join-description": "Volunteers, researchers, journalists — contribute to water transparency in Europe.",
+	"about-join-cta": "Contact us"
 }

--- a/webapp/i18n/fr/default.json
+++ b/webapp/i18n/fr/default.json
@@ -1,6 +1,17 @@
 {
-  "blog-list": "Articles du blog",
-  "blog-resources": "Ressources",
-  "blog-get-info": "Obtenez des informations sur la pollution de l'eau VCM, les actualités, les articles, et plus encore.",
-  "blog-read-more": "Lire la suite"
+	"blog-list": "Articles du blog",
+	"blog-resources": "Ressources",
+	"blog-get-info": "Obtenez des informations sur la pollution de l'eau VCM, les actualités, les articles, et plus encore.",
+	"blog-read-more": "Lire la suite",
+	"about-title": "À propos du projet",
+	"about-subtitle": "Valeurs, équipe et avancées - pour faire confiance et relayer.",
+	"about-description-p1": "VCM Watch est une plateforme d'information sur la présence de chlorure de vinyle monomère (CVM), un gaz cancérigène, dans les réseaux d'eau potable européens. Le CVM migre depuis les canalisations en PVC installées avant 1980 dans l'eau du robinet. En France, des analyses systématiques introduites en 2012 ont révélé des dépassements des limites réglementaires européennes dans plus de 5 000 communes. Cependant, très peu de données sont disponibles au niveau européen, car les analyses ne sont pas actuellement obligatoires, même si un seuil maximal de 0,5 µg/L a été établi par l'Union européenne en 1998.",
+	"about-description-p2": "Pour combler cette lacune, VCM Watch compile toutes les informations disponibles sur les infrastructures d'eau potentiellement contaminées afin de produire une carte des risques à l'échelle européenne. Les données sont collectées auprès des autorités nationales des pays concernés, ou directement auprès des fournisseurs d'eau. Elles peuvent également être soumises par les utilisateurs. Les archives historiques des fabricants de PVC ont également été utilisées pour identifier les risques au niveau national.",
+	"about-description-p3": "L'objectif est d'identifier les zones où une surveillance renforcée est nécessaire et de rendre ces informations accessibles aux citoyens et aux décideurs publics, tout en initiant une collecte de données à grande échelle pour compléter la carte des risques proposée. Le projet est porté par la Chaire de la Terre à l'Université d'Angers, qui a révélé l'ampleur de la contamination au CVM en France en rendant publiques des analyses réalisées par les autorités sanitaires qui n'avaient jamais été divulguées. La plateforme a été développée par des bénévoles de l'association Data for Good, qui ont structuré la base de données, conçu la carte et construit le site. Elle a également été enrichie par une enquête menée conjointement avec le réseau European Investigative Collaborations de journalistes. Enfin, elle a bénéficié des contributions de nombreux citoyens bénévoles qui ont partagé des analyses réalisées localement et identifié des rapports pertinents pour aider à construire la base de données.",
+	"about-team-title": "L'équipe",
+	"about-team-product": "Team Product",
+	"about-team-legal": "Team Legal",
+	"about-join-title": "Vous voulez rejoindre VCM Watch ?",
+	"about-join-description": "Bénévoles, chercheurs, journalistes - contribuez à la transparence de l'eau en Europe.",
+	"about-join-cta": "Nous contacter"
 }


### PR DESCRIPTION
Closes #55

## Changes

- **About page** with 4 sections: header, project description card, team cards (Product & Legal), and join CTA
- **TeamCard component** — reusable card with avatar initials, name, and role
- **i18n support** — all text in en/fr translation files
- **Footer** — email updated to contact@vcm-watch.eu and made clickable (mailto link)