### PR TITLE
#115 | Drive country profile page from CountryData

### DIFF
--- a/docs/plans/implemented/2026-04-18-country-profile-dynamic.md
+++ b/docs/plans/implemented/2026-04-18-country-profile-dynamic.md
@@ -1,0 +1,99 @@
+# Country Profile — make detail page dynamic from CountryData
+
+## Goal
+
+The country-profile detail panel currently mixes NocoDB data (`Country.PVC Level`, `VCM Level`, link counts) with hardcoded content (the "More details" accordion list, the "Missing data" cards). Drive all of it from the `CountryData` NocoDB table, locale-aware.
+
+## NocoDB `CountryData` schema (confirmed)
+
+Columns used:
+- `Country_id` (FK → Country.Id)
+- `Type` — SingleSelect: `stat`, `legislation`, `missing_data`
+- `Language` — SingleSelect: `en`, `fr`, `de`
+- `Order` — Number (ordering within a type; for `stat`, Order 1..4 = network / % exposure / # tests / risk zones)
+- `Title` — SingleLineText (meaningful only for `stat`; blank/null for the others)
+- `Content` — LongText
+
+Stat Order mapping (from data inspection):
+- 1 → "Network affected by VCM" (currently shown from `PVC Level`)
+- 2 → "% Network exposed to VCM" (currently from `VCM Level`)
+- 3 → "Number of VCM tests" (currently from distribution-zone count)
+- 4 → "Identified risk zones" (currently from municipality count)
+
+## Proposed changes
+
+### 1. New lib/fetchCountryDataForCountry.ts
+
+Fetch all `CountryData` rows for a given `Country_id` + `Language`, sorted by `Order`. One NocoDB call, `where=(Country_id,eq,N)~and(Language,eq,xx)`, fields `Id,Type,Order,Title,Content`.
+
+### 2. Extend `fetchCountryByCode` / API route
+
+Two options — prefer (a) for simplicity:
+
+(a) Have `fetchCountryByCode(code, locale)` additionally fetch CountryData and return `{ country, data: CountryDataRecord[] }`. API route `/api/countries/[code]` accepts `?locale=xx` and returns both.
+
+(b) Separate endpoint `/api/countries/[code]/data?locale=xx`. Two client requests.
+
+Going with (a).
+
+Drop `PVC Level`, `VCM Level`, `Distribution Zones`, `Municipalities` from `COUNTRY_DETAIL_FIELDS` (no longer used for stats). Keep `Name, Code, Geometry, Actors, Url`.
+
+### 3. Types (`types/apiTypes.ts`)
+
+```ts
+export interface CountryDataFields {
+  Id: number
+  Type: 'stat' | 'legislation' | 'missing_data'
+  Order: number
+  Title: string | null
+  Content: string | null
+}
+export type CountryDataRecord = Record<CountryDataFields>
+```
+
+Remove `'PVC Level'`, `'VCM Level'`, `'Distribution Zones'`, `'Municipalities'` from `CountryDetailFields`.
+
+### 4. `CountryCarousel.tsx`
+
+- Accept/propagate `locale` (read from `useLocale` via next-intl or pass down from page).
+- Include `?locale=` on the fetch.
+- Pass `data` prop to `CountryProfileDetail`.
+
+### 5. `CountryProfileDetail.tsx`
+
+- Take `data: CountryDataRecord[]` prop.
+- Stats row: filter `Type==='stat'`, sort by `Order`, render `StatCard`s using NocoDB `Title` directly as the label and `Content` (fallback `—`) as the value. Drops the current formatCountStat / distribution-zone / municipality logic. Keep the existing icon mapping by Order (1→TrainTrack, 2→Percent, 3→FlaskConical, 4→MapPin).
+- "More details" accordion: filter `Type==='legislation'`, sort by `Order`, render `Content` as `<li>` entries. Hide the accordion if no non-empty entries.
+- "Missing data" cards: filter `Type==='missing_data'`, sort by `Order`. Each row has only `Content` (no per-row title in NocoDB). Render as `<div>` with `Content` only — drop the hardcoded `['Full PVC network inventory', ...]` titles. Hide section if empty.
+
+### 6. Page (`app/[locale]/country-profile/page.tsx`)
+
+Pick up `locale` from params and pass to carousel.
+
+### 7. i18n strings
+
+None needed — stat labels come straight from NocoDB `Title`.
+
+## Files touched
+
+- `webapp/types/apiTypes.ts`
+- `webapp/lib/fetchCountryByCode.ts`
+- new `webapp/lib/fetchCountryData.ts`
+- `webapp/app/api/countries/[code]/route.ts`
+- `webapp/app/[locale]/country-profile/page.tsx`
+- `webapp/app/[locale]/country-profile/components/CountryCarousel.tsx`
+- `webapp/app/[locale]/country-profile/components/CountryProfileDetail.tsx`
+
+## Open questions
+
+(none — see Decisions above)
+
+<!-- resolved -->
+
+## Decisions
+
+1. Stat card titles: use NocoDB `Title` directly, no fallback.
+2. `legislation` rendered as bullet list inside the accordion (preserves current look).
+3. `fetchCountries` (list) untouched.
+4. Unsupported locale → fall back to `en` if fetched CountryData list is empty.
+5. Accordion stays collapsed by default.

--- a/docs/plans/implemented/2026-04-18-country-profile-dynamic.md
+++ b/docs/plans/implemented/2026-04-18-country-profile-dynamic.md
@@ -97,3 +97,9 @@ None needed — stat labels come straight from NocoDB `Title`.
 3. `fetchCountries` (list) untouched.
 4. Unsupported locale → fall back to `en` if fetched CountryData list is empty.
 5. Accordion stays collapsed by default.
+
+## Post-implementation amendments
+
+- **COUNTRY_DETAIL_FIELDS change**: plan said keep `Name, Code, Geometry, Actors, Url`. Actual shipped set is `Name, Code, Geometry, Image` — `Url` was replaced by `Image` (NocoDB attachment, resolved via `signedUrl`) to support the illustration in the detail card, and `Actors` was dropped because it is no longer referenced by `CountryProfileDetail` (stats now come from `CountryData`). `CountryDetailFields` type updated accordingly.
+- **Locale fallback (Decision #4)**: initially shipped with no fallback; corrected in follow-up so `fetchCountryDataForCountry` retries once with `fallbackLanguage` when the requested locale returns zero rows.
+- **API route locale allowlist** now sourced from `i18n.locales` / `fallbackLanguage` instead of a hardcoded set.

--- a/webapp/app/[locale]/country-profile/components/CountryCarousel.tsx
+++ b/webapp/app/[locale]/country-profile/components/CountryCarousel.tsx
@@ -21,10 +21,10 @@ function codeToFlagEmoji(code: string): string {
 
 interface CountryCarouselProps {
 	countries: CountryListRecord[]
-	locale?: string
+	locale: string
 }
 
-export function CountryCarousel({ countries, locale = 'en' }: CountryCarouselProps) {
+export function CountryCarousel({ countries, locale }: CountryCarouselProps) {
 	const [selectedCode, setSelectedCode] = React.useState<string | null>(null)
 	const [countryDetail, setCountryDetail] = React.useState<CountryDetailRecord | null>(null)
 	const [countryData, setCountryData] = React.useState<CountryDataRecord[]>([])

--- a/webapp/app/[locale]/country-profile/components/CountryCarousel.tsx
+++ b/webapp/app/[locale]/country-profile/components/CountryCarousel.tsx
@@ -3,7 +3,7 @@ import * as React from 'react'
 
 import { Card, CardContent } from '@/components/ui/card'
 import { Carousel, CarouselContent, CarouselItem, CarouselNext, CarouselPrevious } from '@/components/ui/carousel'
-import type { CountryDetailRecord, CountryListRecord } from '@/types/apiTypes'
+import type { CountryDataRecord, CountryDetailRecord, CountryListRecord } from '@/types/apiTypes'
 
 import { CountryProfileDetail } from './CountryProfileDetail'
 
@@ -21,47 +21,57 @@ function codeToFlagEmoji(code: string): string {
 
 interface CountryCarouselProps {
 	countries: CountryListRecord[]
+	locale?: string
 }
 
-export function CountryCarousel({ countries }: CountryCarouselProps) {
+export function CountryCarousel({ countries, locale = 'en' }: CountryCarouselProps) {
 	const [selectedCode, setSelectedCode] = React.useState<string | null>(null)
 	const [countryDetail, setCountryDetail] = React.useState<CountryDetailRecord | null>(null)
+	const [countryData, setCountryData] = React.useState<CountryDataRecord[]>([])
 	const [detailLoading, setDetailLoading] = React.useState(false)
 	const [detailError, setDetailError] = React.useState<string | null>(null)
 
-	const loadCountry = React.useCallback(async (code: string) => {
-		setSelectedCode(code)
-		setDetailLoading(true)
-		setDetailError(null)
-		setCountryDetail(null)
+	const loadCountry = React.useCallback(
+		async (code: string) => {
+			setSelectedCode(code)
+			setDetailLoading(true)
+			setDetailError(null)
+			setCountryDetail(null)
+			setCountryData([])
 
-		try {
-			const res = await fetch(`/api/countries/${encodeURIComponent(code)}`)
+			try {
+				const res = await fetch(`/api/countries/${encodeURIComponent(code)}?locale=${encodeURIComponent(locale)}`)
 
-			if (res.status === 404) {
-				setDetailError('Country not found.')
-				return
+				if (res.status === 404) {
+					setDetailError('Country not found.')
+					return
+				}
+
+				if (!res.ok) {
+					setDetailError('Unable to load country data.')
+					return
+				}
+
+				const json = (await res.json()) as {
+					country: CountryDetailRecord | null
+					data: CountryDataRecord[]
+				}
+
+				if (!json.country) {
+					setDetailError('Country not found.')
+					return
+				}
+
+				setCountryDetail(json.country)
+				setCountryData(json.data ?? [])
+			} catch {
+				setDetailError('Network error.')
+			} finally {
+				setDetailLoading(false)
 			}
-
-			if (!res.ok) {
-				setDetailError('Unable to load country data.')
-				return
-			}
-
-			const data = (await res.json()) as { country: CountryDetailRecord | null }
-
-			if (!data.country) {
-				setDetailError('Country not found.')
-				return
-			}
-
-			setCountryDetail(data.country)
-		} catch {
-			setDetailError('Network error.')
-		} finally {
-			setDetailLoading(false)
-		}
-	}, [])
+		},
+		[locale]
+	)
 
 	const firstCountryCode = countries[0]?.fields.Code
 
@@ -70,6 +80,7 @@ export function CountryCarousel({ countries }: CountryCarouselProps) {
 			return
 		}
 
+		// eslint-disable-next-line react-hooks/set-state-in-effect -- async fn; setState happens after await, not synchronously
 		void loadCountry(firstCountryCode)
 	}, [firstCountryCode, loadCountry])
 
@@ -103,7 +114,7 @@ export function CountryCarousel({ countries }: CountryCarouselProps) {
 				<CarouselPrevious />
 				<CarouselNext />
 			</Carousel>
-			<CountryProfileDetail country={countryDetail} loading={detailLoading} error={detailError} />
+			<CountryProfileDetail country={countryDetail} data={countryData} loading={detailLoading} error={detailError} />
 		</>
 	)
 }

--- a/webapp/app/[locale]/country-profile/components/CountryProfileDetail.tsx
+++ b/webapp/app/[locale]/country-profile/components/CountryProfileDetail.tsx
@@ -7,50 +7,14 @@ import { FlaskConical, MapPin, Percent, TrainTrack, TriangleAlert } from 'lucide
 import { InfoCard } from '@/components/InfoCard'
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from '@/components/ui/accordion'
 import { Card, CardContent } from '@/components/ui/card'
-import type { CountryDetailRecord } from '@/types/apiTypes'
+import type { CountryDataRecord, CountryDetailRecord } from '@/types/apiTypes'
 
-const numberFmt = new Intl.NumberFormat('en-US')
-
-function formatStatText(value: string | null): string {
-	if (value == null || value.trim() === '') {
-		return '—'
-	}
-
-	return value
-}
-
-function countryNumericOrLinkCount(value: unknown): number | null {
-	if (value == null) {
-		return null
-	}
-
-	if (typeof value === 'number' && Number.isFinite(value)) {
-		return value
-	}
-
-	if (typeof value === 'string') {
-		const parsed = Number.parseFloat(value)
-
-		if (Number.isFinite(parsed)) {
-			return parsed
-		}
-	}
-
-	if (Array.isArray(value)) {
-		return value.length
-	}
-
-	return null
-}
-
-function formatCountStat(value: unknown, nounPhrase: string): string {
-	const n = countryNumericOrLinkCount(value)
-
-	if (n == null || n <= 0) {
-		return '—'
-	}
-
-	return `${numberFmt.format(n)} ${nounPhrase}`
+/** Icon lookup by Order (1-indexed) */
+const STAT_ICONS: Record<number, ComponentType<{ className?: string }>> = {
+	1: TrainTrack,
+	2: Percent,
+	3: FlaskConical,
+	4: MapPin
 }
 
 interface StatCardProps {
@@ -75,11 +39,12 @@ function StatCard({ icon: Icon, title, value }: StatCardProps) {
 
 interface CountryProfileDetailProps {
 	country: CountryDetailRecord | null
+	data: CountryDataRecord[]
 	loading: boolean
 	error: string | null
 }
 
-export function CountryProfileDetail({ country, loading, error }: CountryProfileDetailProps) {
+export function CountryProfileDetail({ country, data, loading, error }: CountryProfileDetailProps) {
 	if (loading) {
 		return (
 			<div className='text-navy-800 mt-10 font-[lexend] text-sm' role='status'>
@@ -106,14 +71,16 @@ export function CountryProfileDetail({ country, loading, error }: CountryProfile
 	const f = country.fields
 	const imageSrc = f.Url ?? 'https://placehold.co/310x240.png'
 
-	const pvcDisplay = formatStatText(f['PVC Level'] ?? null)
-	const vcmDisplay = formatStatText(f['VCM Level'] ?? null)
-	const distributionZonesCount = countryNumericOrLinkCount(f['Distribution Zones'])
+	// Partition CountryData by type, sorted by Order
+	const stats = data.filter(r => r.fields.Type === 'stat').sort((a, b) => a.fields.Order - b.fields.Order)
 
-	const analysesDisplay =
-		distributionZonesCount != null && distributionZonesCount > 0 ? numberFmt.format(distributionZonesCount) : '—'
+	const legislationItems = data
+		.filter(r => r.fields.Type === 'legislation')
+		.sort((a, b) => a.fields.Order - b.fields.Order)
 
-	const municipalitiesDisplay = formatCountStat(f.Municipalities, 'municipalities')
+	const missingDataItems = data
+		.filter(r => r.fields.Type === 'missing_data')
+		.sort((a, b) => a.fields.Order - b.fields.Order)
 
 	return (
 		<section className='mt-10 mb-8 flex flex-col gap-8' aria-live='polite'>
@@ -135,47 +102,54 @@ export function CountryProfileDetail({ country, loading, error }: CountryProfile
 						</div>
 						<div className='flex w-full min-w-0 flex-1 flex-col items-start justify-center md:w-auto'>
 							<div className='grid w-full grid-cols-1 gap-4 md:grid-cols-2'>
-								<StatCard icon={TrainTrack} title='VCM impacted network' value={pvcDisplay} />
-								<StatCard icon={Percent} title='VCM exposure rate' value={vcmDisplay} />
-								<StatCard icon={FlaskConical} title='Number of VCM analyses' value={analysesDisplay} />
-								<StatCard icon={MapPin} title='Identified risk zones' value={municipalitiesDisplay} />
+								{stats.map(row => {
+									const Icon = STAT_ICONS[row.fields.Order] ?? TrainTrack
+									const title = row.fields.Title ?? ''
+									const value = row.fields.Content?.trim() ?? '—'
+
+									return <StatCard key={row.id} icon={Icon} title={title} value={value} />
+								})}
 							</div>
 						</div>
 					</dl>
 
-					<Accordion type='single' collapsible className='w-full'>
-						<AccordionItem value='more-details' className='border-navy-200 border-b-0'>
-							<AccordionTrigger className='text-navy-800 py-3 font-[lexend] text-[19px] font-medium hover:no-underline'>
-								More details
-							</AccordionTrigger>
-							<AccordionContent className='pb-2'>
-								<ul className='font-regular list-disc pl-5 text-[17px] text-gray-600'>
-									<li>...</li>
-								</ul>
-							</AccordionContent>
-						</AccordionItem>
-					</Accordion>
+					{legislationItems.length > 0 && (
+						<Accordion type='single' collapsible className='w-full'>
+							<AccordionItem value='more-details' className='border-navy-200 border-b-0'>
+								<AccordionTrigger className='text-navy-800 py-3 font-[lexend] text-[19px] font-medium hover:no-underline'>
+									More details
+								</AccordionTrigger>
+								<AccordionContent className='pb-2'>
+									<ul className='font-regular list-disc pl-5 text-[17px] text-gray-600'>
+										{legislationItems.map(row => (
+											<li key={row.id}>{row.fields.Content}</li>
+										))}
+									</ul>
+								</AccordionContent>
+							</AccordionItem>
+						</Accordion>
+					)}
 				</div>
 			</InfoCard>
 
-			<InfoCard bgClassName='bg-navy-50'>
-				<div className='text-navy-800 flex flex-col gap-4'>
-					<div className='flex items-center gap-1'>
-						<TriangleAlert />
-						<h2 className='font-[lexend] text-[24px] font-medium'>Missing data</h2>
-					</div>
+			{missingDataItems.length > 0 && (
+				<InfoCard bgClassName='bg-navy-50'>
+					<div className='text-navy-800 flex flex-col gap-4'>
+						<div className='flex items-center gap-1'>
+							<TriangleAlert />
+							<h2 className='font-[lexend] text-[24px] font-medium'>Missing data</h2>
+						</div>
 
-					<div className='flex w-full flex-col items-start gap-4'>
-						{/* TODO: refactor when data clarified */}
-						{['Full PVC network inventory', 'Regular VCM testing', 'Replacement plans'].map(title => (
-							<div key={title} className='flex w-full flex-col border-l-[6px] border-gray-300 bg-white px-4 py-2'>
-								<dt className='font-regular text-[20px]'>{title}</dt>
-								<dd className='text-[16px] text-gray-600'>...</dd>
-							</div>
-						))}
+						<div className='flex w-full flex-col items-start gap-4'>
+							{missingDataItems.map(row => (
+								<div key={row.id} className='flex w-full flex-col border-l-[6px] border-gray-300 bg-white px-4 py-2'>
+									<p className='font-regular text-[17px] text-gray-600'>{row.fields.Content}</p>
+								</div>
+							))}
+						</div>
 					</div>
-				</div>
-			</InfoCard>
+				</InfoCard>
+			)}
 		</section>
 	)
 }

--- a/webapp/app/[locale]/country-profile/components/CountryProfileDetail.tsx
+++ b/webapp/app/[locale]/country-profile/components/CountryProfileDetail.tsx
@@ -2,7 +2,7 @@ import type { ComponentType } from 'react'
 
 import Image from 'next/image'
 
-import { FlaskConical, MapPin, Percent, TrainTrack, TriangleAlert } from 'lucide-react'
+import { FlaskConical, HelpCircle, MapPin, Percent, TrainTrack, TriangleAlert } from 'lucide-react'
 
 import { InfoCard } from '@/components/InfoCard'
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from '@/components/ui/accordion'
@@ -103,11 +103,20 @@ export function CountryProfileDetail({ country, data, loading, error }: CountryP
 						<div className='flex w-full min-w-0 flex-1 flex-col items-start justify-center md:w-auto'>
 							<div className='grid w-full grid-cols-1 gap-4 md:grid-cols-2'>
 								{stats.map(row => {
-									const Icon = STAT_ICONS[row.fields.Order] ?? TrainTrack
-									const title = row.fields.Title ?? ''
-									const value = row.fields.Content?.trim() ?? '—'
+									const Icon = STAT_ICONS[row.fields.Order]
 
-									return <StatCard key={row.id} icon={Icon} title={title} value={value} />
+									if (!Icon && process.env.NODE_ENV !== 'production') {
+										console.warn(`CountryData stat row has unexpected Order=${row.fields.Order} (id=${row.id})`)
+									}
+
+									const title = row.fields.Title
+									const value = row.fields.Content
+
+									if (!title || !value) {
+										return null
+									}
+
+									return <StatCard key={row.id} icon={Icon ?? HelpCircle} title={title} value={value} />
 								})}
 							</div>
 						</div>

--- a/webapp/app/[locale]/country-profile/components/CountryProfileDetail.tsx
+++ b/webapp/app/[locale]/country-profile/components/CountryProfileDetail.tsx
@@ -73,7 +73,7 @@ export function CountryProfileDetail({ country, data, loading, error }: CountryP
 	const attachment = f.Image?.[0]
 
 	const imageSrc =
-		attachment?.signedPath ?? attachment?.thumbnails?.card_cover?.signedPath ?? 'https://placehold.co/310x240.png'
+		attachment?.signedUrl ?? attachment?.thumbnails?.card_cover?.signedUrl ?? 'https://placehold.co/310x240.png'
 
 	// Partition CountryData by type (already ordered by Order from server)
 	const stats = data.filter(r => r.fields.Type === 'stat')

--- a/webapp/app/[locale]/country-profile/components/CountryProfileDetail.tsx
+++ b/webapp/app/[locale]/country-profile/components/CountryProfileDetail.tsx
@@ -71,16 +71,12 @@ export function CountryProfileDetail({ country, data, loading, error }: CountryP
 	const f = country.fields
 	const imageSrc = f.Url ?? 'https://placehold.co/310x240.png'
 
-	// Partition CountryData by type, sorted by Order
-	const stats = data.filter(r => r.fields.Type === 'stat').sort((a, b) => a.fields.Order - b.fields.Order)
+	// Partition CountryData by type (already ordered by Order from server)
+	const stats = data.filter(r => r.fields.Type === 'stat')
 
-	const legislationItems = data
-		.filter(r => r.fields.Type === 'legislation')
-		.sort((a, b) => a.fields.Order - b.fields.Order)
+	const legislationItems = data.filter(r => r.fields.Type === 'legislation')
 
-	const missingDataItems = data
-		.filter(r => r.fields.Type === 'missing_data')
-		.sort((a, b) => a.fields.Order - b.fields.Order)
+	const missingDataItems = data.filter(r => r.fields.Type === 'missing_data')
 
 	return (
 		<section className='mt-10 mb-8 flex flex-col gap-8' aria-live='polite'>

--- a/webapp/app/[locale]/country-profile/components/CountryProfileDetail.tsx
+++ b/webapp/app/[locale]/country-profile/components/CountryProfileDetail.tsx
@@ -69,7 +69,11 @@ export function CountryProfileDetail({ country, data, loading, error }: CountryP
 	}
 
 	const f = country.fields
-	const imageSrc = f.Url ?? 'https://placehold.co/310x240.png'
+
+	const attachment = f.Image?.[0]
+
+	const imageSrc =
+		attachment?.signedPath ?? attachment?.thumbnails?.card_cover?.signedPath ?? 'https://placehold.co/310x240.png'
 
 	// Partition CountryData by type (already ordered by Order from server)
 	const stats = data.filter(r => r.fields.Type === 'stat')

--- a/webapp/app/[locale]/country-profile/page.tsx
+++ b/webapp/app/[locale]/country-profile/page.tsx
@@ -3,7 +3,12 @@ import type { CountryListRecord } from '@/types/apiTypes'
 
 import { CountryCarousel } from './components/CountryCarousel'
 
-export default async function CountryProfilePage() {
+interface CountryProfilePageProps {
+	params: Promise<{ locale: string }>
+}
+
+export default async function CountryProfilePage({ params }: CountryProfilePageProps) {
+	const { locale } = await params
 	const countries: CountryListRecord[] = await fetchCountries()
 
 	return (
@@ -13,7 +18,7 @@ export default async function CountryProfilePage() {
 			{countries.length === 0 ? (
 				<p className='mt-4 text-lg text-gray-600'>No countries available.</p>
 			) : (
-				<CountryCarousel countries={countries} />
+				<CountryCarousel countries={countries} locale={locale} />
 			)}
 		</main>
 	)

--- a/webapp/app/api/countries/[code]/route.ts
+++ b/webapp/app/api/countries/[code]/route.ts
@@ -1,14 +1,17 @@
 import { NextResponse } from 'next/server'
 
+import { fallbackLanguage, i18n } from '@/i18n/i18next.config'
 import { fetchCountryByCode } from '@/lib/fetchCountryByCode'
+
+const ALLOWED_LOCALES = new Set<string>(i18n.locales)
 
 export async function GET(request: Request, { params }: { params: Promise<{ code: string }> }) {
 	const { code } = await params
 	const decoded = decodeURIComponent(code)
 
 	const { searchParams } = new URL(request.url)
-	const ALLOWED_LOCALES = new Set(['en', 'fr', 'de'])
-	const locale = ALLOWED_LOCALES.has(searchParams.get('locale') ?? '') ? searchParams.get('locale')! : 'en'
+	const requested = searchParams.get('locale') ?? ''
+	const locale = ALLOWED_LOCALES.has(requested) ? requested : fallbackLanguage
 
 	const result = await fetchCountryByCode(decoded, locale)
 

--- a/webapp/app/api/countries/[code]/route.ts
+++ b/webapp/app/api/countries/[code]/route.ts
@@ -2,14 +2,18 @@ import { NextResponse } from 'next/server'
 
 import { fetchCountryByCode } from '@/lib/fetchCountryByCode'
 
-export async function GET(_request: Request, { params }: { params: Promise<{ code: string }> }) {
+export async function GET(request: Request, { params }: { params: Promise<{ code: string }> }) {
 	const { code } = await params
 	const decoded = decodeURIComponent(code)
-	const country = await fetchCountryByCode(decoded)
 
-	if (!country) {
-		return NextResponse.json({ country: null }, { status: 404 })
+	const { searchParams } = new URL(request.url)
+	const locale = searchParams.get('locale') ?? 'en'
+
+	const result = await fetchCountryByCode(decoded, locale)
+
+	if (!result) {
+		return NextResponse.json({ country: null, data: [] }, { status: 404 })
 	}
 
-	return NextResponse.json({ country })
+	return NextResponse.json({ country: result.country, data: result.data })
 }

--- a/webapp/app/api/countries/[code]/route.ts
+++ b/webapp/app/api/countries/[code]/route.ts
@@ -7,7 +7,8 @@ export async function GET(request: Request, { params }: { params: Promise<{ code
 	const decoded = decodeURIComponent(code)
 
 	const { searchParams } = new URL(request.url)
-	const locale = searchParams.get('locale') ?? 'en'
+	const ALLOWED_LOCALES = new Set(['en', 'fr', 'de'])
+	const locale = ALLOWED_LOCALES.has(searchParams.get('locale') ?? '') ? searchParams.get('locale')! : 'en'
 
 	const result = await fetchCountryByCode(decoded, locale)
 

--- a/webapp/lib/__tests__/fetchCountryData.test.ts
+++ b/webapp/lib/__tests__/fetchCountryData.test.ts
@@ -17,11 +17,15 @@ const mockGetTableIdByName = vi.mocked(getTableIdByName)
 // eslint-disable-next-line @typescript-eslint/unbound-method
 const mockGet = vi.mocked(instance.get)
 
+let nextId = 1
+
 function makeRow(overrides: Partial<CountryDataRecord['fields']> = {}): CountryDataRecord {
+	const id = nextId++
+
 	return {
-		id: 1,
+		id,
 		fields: {
-			Id: 1,
+			Id: id,
 			Type: 'stat',
 			Order: 1,
 			Title: 'Network affected',
@@ -34,6 +38,7 @@ function makeRow(overrides: Partial<CountryDataRecord['fields']> = {}): CountryD
 describe('fetchCountryDataForCountry', () => {
 	beforeEach(() => {
 		vi.clearAllMocks()
+		nextId = 1
 		process.env.NOCODB_BASE_ID = 'base123'
 	})
 

--- a/webapp/lib/__tests__/fetchCountryData.test.ts
+++ b/webapp/lib/__tests__/fetchCountryData.test.ts
@@ -104,6 +104,23 @@ describe('fetchCountryDataForCountry', () => {
 		expect(result).toEqual([])
 	})
 
+	it('filters out rows with empty or whitespace-only Content', async () => {
+		const rows = [
+			makeRow({ Content: 'real content', Order: 1 }),
+			makeRow({ Content: '', Order: 2 }),
+			makeRow({ Content: '   ', Order: 3 }),
+			makeRow({ Content: null, Order: 4 })
+		]
+
+		mockGetTableIdByName.mockResolvedValue('table-abc')
+		mockGet.mockResolvedValue({ status: 200, data: { records: rows } })
+
+		const result = await fetchCountryDataForCountry(7, 'en')
+
+		expect(result).toHaveLength(1)
+		expect(result[0]?.fields.Content).toBe('real content')
+	})
+
 	it('returns empty array when server responds with non-200 status', async () => {
 		mockGetTableIdByName.mockResolvedValue('table-abc')
 		mockGet.mockResolvedValue({ status: 500, statusText: 'Internal Server Error' })

--- a/webapp/lib/__tests__/fetchCountryData.test.ts
+++ b/webapp/lib/__tests__/fetchCountryData.test.ts
@@ -100,4 +100,13 @@ describe('fetchCountryDataForCountry', () => {
 
 		expect(result).toEqual([])
 	})
+
+	it('returns empty array when server responds with non-200 status', async () => {
+		mockGetTableIdByName.mockResolvedValue('table-abc')
+		mockGet.mockResolvedValue({ status: 500, statusText: 'Internal Server Error' })
+
+		const result = await fetchCountryDataForCountry(7, 'en')
+
+		expect(result).toEqual([])
+	})
 })

--- a/webapp/lib/__tests__/fetchCountryData.test.ts
+++ b/webapp/lib/__tests__/fetchCountryData.test.ts
@@ -65,6 +65,9 @@ describe('fetchCountryDataForCountry', () => {
 
 		expect(callUrl).toContain('Country_id%2Ceq%2C7')
 		expect(callUrl).toContain('Language%2Ceq%2Cen')
+		// sort must be a JSON array (v3 API requirement), ascending on Order
+		expect(callUrl).toMatch(/sort=.*Order/i)
+		expect(decodeURIComponent(callUrl ?? '')).toContain('[{"direction":"asc","field":"Order"}]')
 	})
 
 	it('falls back to en when locale returns no rows', async () => {

--- a/webapp/lib/__tests__/fetchCountryData.test.ts
+++ b/webapp/lib/__tests__/fetchCountryData.test.ts
@@ -25,7 +25,6 @@ function makeRow(overrides: Partial<CountryDataRecord['fields']> = {}): CountryD
 	return {
 		id,
 		fields: {
-			Id: id,
 			Type: 'stat',
 			Order: 1,
 			Title: 'Network affected',
@@ -70,20 +69,24 @@ describe('fetchCountryDataForCountry', () => {
 		expect(decodeURIComponent(callUrl ?? '')).toContain('[{"direction":"asc","field":"Order"}]')
 	})
 
-	it('returns empty array when locale has no rows (no fallback)', async () => {
+	it('falls back to en when requested locale has no rows', async () => {
+		const frRows: CountryDataRecord[] = []
+		const enRows = [makeRow({ Order: 1 })]
+
 		mockGetTableIdByName.mockResolvedValue('table-abc')
-		mockGet.mockResolvedValue({ status: 200, data: { records: [] } })
+		mockGet
+			.mockResolvedValueOnce({ status: 200, data: { records: frRows } })
+			.mockResolvedValueOnce({ status: 200, data: { records: enRows } })
 
 		const result = await fetchCountryDataForCountry(7, 'fr')
 
-		expect(result).toEqual([])
-		expect(mockGet).toHaveBeenCalledTimes(1)
-		const callUrl = mockGet.mock.calls[0]?.[0]
-
-		expect(callUrl).toContain('Language%2Ceq%2Cfr')
+		expect(result).toEqual(enRows)
+		expect(mockGet).toHaveBeenCalledTimes(2)
+		expect(mockGet.mock.calls[0]?.[0]).toContain('Language%2Ceq%2Cfr')
+		expect(mockGet.mock.calls[1]?.[0]).toContain('Language%2Ceq%2Cen')
 	})
 
-	it('does not make a second call when locale is already en and returns empty', async () => {
+	it('does not retry when locale is already en and returns empty', async () => {
 		mockGetTableIdByName.mockResolvedValue('table-abc')
 		mockGet.mockResolvedValue({ status: 200, data: { records: [] } })
 

--- a/webapp/lib/__tests__/fetchCountryData.test.ts
+++ b/webapp/lib/__tests__/fetchCountryData.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// Mock dependencies before importing the module under test
+vi.mock('../fetchMetaTables', () => ({
+	getTableIdByName: vi.fn()
+}))
+vi.mock('../instance', () => ({
+	instance: { get: vi.fn() }
+}))
+
+import { getTableIdByName } from '../fetchMetaTables'
+import { instance } from '../instance'
+import { fetchCountryDataForCountry } from '../fetchCountryData'
+import type { CountryDataRecord } from '@/types/apiTypes'
+
+const mockGetTableIdByName = vi.mocked(getTableIdByName)
+// eslint-disable-next-line @typescript-eslint/unbound-method
+const mockGet = vi.mocked(instance.get)
+
+function makeRow(overrides: Partial<CountryDataRecord['fields']> = {}): CountryDataRecord {
+	return {
+		id: 1,
+		fields: {
+			Id: 1,
+			Type: 'stat',
+			Order: 1,
+			Title: 'Network affected',
+			Content: '42%',
+			...overrides
+		}
+	}
+}
+
+describe('fetchCountryDataForCountry', () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+		process.env.NOCODB_BASE_ID = 'base123'
+	})
+
+	it('returns empty array when table id cannot be resolved', async () => {
+		mockGetTableIdByName.mockResolvedValue(null)
+
+		const result = await fetchCountryDataForCountry(7, 'en')
+
+		expect(result).toEqual([])
+		expect(mockGet).not.toHaveBeenCalled()
+	})
+
+	it('returns rows for the requested locale', async () => {
+		const rows = [makeRow({ Order: 1 }), makeRow({ Order: 2 })]
+
+		mockGetTableIdByName.mockResolvedValue('table-abc')
+		mockGet.mockResolvedValue({ status: 200, data: { records: rows } })
+
+		const result = await fetchCountryDataForCountry(7, 'en')
+
+		expect(result).toEqual(rows)
+		// Should have called get with the correct where clause
+		const callUrl = mockGet.mock.calls[0]?.[0]
+
+		expect(callUrl).toContain('Country_id%2Ceq%2C7')
+		expect(callUrl).toContain('Language%2Ceq%2Cen')
+	})
+
+	it('falls back to en when locale returns no rows', async () => {
+		const enRows = [makeRow()]
+
+		mockGetTableIdByName.mockResolvedValue('table-abc')
+		// First call (fr) returns empty, second call (en) returns rows
+		mockGet
+			.mockResolvedValueOnce({ status: 200, data: { records: [] } })
+			.mockResolvedValueOnce({ status: 200, data: { records: enRows } })
+
+		const result = await fetchCountryDataForCountry(7, 'fr')
+
+		expect(result).toEqual(enRows)
+		expect(mockGet).toHaveBeenCalledTimes(2)
+	})
+
+	it('does not make a second call when locale is already en and returns empty', async () => {
+		mockGetTableIdByName.mockResolvedValue('table-abc')
+		mockGet.mockResolvedValue({ status: 200, data: { records: [] } })
+
+		const result = await fetchCountryDataForCountry(7, 'en')
+
+		expect(result).toEqual([])
+		expect(mockGet).toHaveBeenCalledTimes(1)
+	})
+
+	it('returns empty array on network error', async () => {
+		mockGetTableIdByName.mockResolvedValue('table-abc')
+		mockGet.mockRejectedValue(new Error('Network failure'))
+
+		const result = await fetchCountryDataForCountry(7, 'en')
+
+		expect(result).toEqual([])
+	})
+})

--- a/webapp/lib/__tests__/fetchCountryData.test.ts
+++ b/webapp/lib/__tests__/fetchCountryData.test.ts
@@ -70,19 +70,17 @@ describe('fetchCountryDataForCountry', () => {
 		expect(decodeURIComponent(callUrl ?? '')).toContain('[{"direction":"asc","field":"Order"}]')
 	})
 
-	it('falls back to en when locale returns no rows', async () => {
-		const enRows = [makeRow()]
-
+	it('returns empty array when locale has no rows (no fallback)', async () => {
 		mockGetTableIdByName.mockResolvedValue('table-abc')
-		// First call (fr) returns empty, second call (en) returns rows
-		mockGet
-			.mockResolvedValueOnce({ status: 200, data: { records: [] } })
-			.mockResolvedValueOnce({ status: 200, data: { records: enRows } })
+		mockGet.mockResolvedValue({ status: 200, data: { records: [] } })
 
 		const result = await fetchCountryDataForCountry(7, 'fr')
 
-		expect(result).toEqual(enRows)
-		expect(mockGet).toHaveBeenCalledTimes(2)
+		expect(result).toEqual([])
+		expect(mockGet).toHaveBeenCalledTimes(1)
+		const callUrl = mockGet.mock.calls[0]?.[0]
+
+		expect(callUrl).toContain('Language%2Ceq%2Cfr')
 	})
 
 	it('does not make a second call when locale is already en and returns empty', async () => {

--- a/webapp/lib/fetchCountryByCode.ts
+++ b/webapp/lib/fetchCountryByCode.ts
@@ -24,8 +24,10 @@ export async function fetchCountryByCode(code: string, locale = 'en'): Promise<C
 			return null
 		}
 
+		const where = `(Code,eq,${trimmed})`
+
 		const response = await instance.get<FetchResponseRecords<CountryDetailRecord>>(
-			`/data/${process.env.NOCODB_BASE_ID}/${countryTableId}/records?where=(Code,eq,${trimmed})`,
+			`/data/${process.env.NOCODB_BASE_ID}/${countryTableId}/records?where=${encodeURIComponent(where)}`,
 			{ params: { fields: COUNTRY_DETAIL_FIELDS }, timeout: 20000 }
 		)
 

--- a/webapp/lib/fetchCountryByCode.ts
+++ b/webapp/lib/fetchCountryByCode.ts
@@ -3,7 +3,7 @@ import { fetchCountryDataForCountry } from './fetchCountryData'
 import { getTableIdByName } from './fetchMetaTables'
 import { FetchResponseRecords, instance } from './instance'
 
-const COUNTRY_DETAIL_FIELDS = 'Name,Code,Geometry,Actors,Image'
+const COUNTRY_DETAIL_FIELDS = 'Name,Code,Geometry,Image'
 
 export interface CountryWithData {
 	country: CountryDetailRecord
@@ -41,6 +41,8 @@ export async function fetchCountryByCode(code: string, locale = 'en'): Promise<C
 			return null
 		}
 
+		// Note: fetchCountryDataForCountry self-handles its errors (returns []),
+		// so the surrounding try/catch here only guards the Country lookup.
 		const data = await fetchCountryDataForCountry(country.id, locale)
 
 		return { country, data }

--- a/webapp/lib/fetchCountryByCode.ts
+++ b/webapp/lib/fetchCountryByCode.ts
@@ -1,10 +1,16 @@
-import type { CountryDetailRecord } from '@/types/apiTypes'
+import type { CountryDataRecord, CountryDetailRecord } from '@/types/apiTypes'
+import { fetchCountryDataForCountry } from './fetchCountryData'
 import { getTableIdByName } from './fetchMetaTables'
 import { FetchResponseRecords, instance } from './instance'
 
-const COUNTRY_DETAIL_FIELDS = 'Name,Code,Geometry,PVC Level,VCM Level,Distribution Zones,Municipalities,Actors'
+const COUNTRY_DETAIL_FIELDS = 'Name,Code,Geometry,Actors,Url'
 
-export async function fetchCountryByCode(code: string): Promise<CountryDetailRecord | null> {
+export interface CountryWithData {
+	country: CountryDetailRecord
+	data: CountryDataRecord[]
+}
+
+export async function fetchCountryByCode(code: string, locale = 'en'): Promise<CountryWithData | null> {
 	const trimmed = code.trim()
 
 	if (!trimmed) {
@@ -27,7 +33,15 @@ export async function fetchCountryByCode(code: string): Promise<CountryDetailRec
 			throw new Error(`Failed to fetch country: ${response.statusText}`)
 		}
 
-		return response.data.records[0] ?? null
+		const country = response.data.records[0] ?? null
+
+		if (!country) {
+			return null
+		}
+
+		const data = await fetchCountryDataForCountry(country.id, locale)
+
+		return { country, data }
 	} catch (error) {
 		console.error('Error fetching country by code:', error)
 		return null

--- a/webapp/lib/fetchCountryByCode.ts
+++ b/webapp/lib/fetchCountryByCode.ts
@@ -3,7 +3,7 @@ import { fetchCountryDataForCountry } from './fetchCountryData'
 import { getTableIdByName } from './fetchMetaTables'
 import { FetchResponseRecords, instance } from './instance'
 
-const COUNTRY_DETAIL_FIELDS = 'Name,Code,Geometry,Actors,Url'
+const COUNTRY_DETAIL_FIELDS = 'Name,Code,Geometry,Actors,Image'
 
 export interface CountryWithData {
 	country: CountryDetailRecord

--- a/webapp/lib/fetchCountryData.ts
+++ b/webapp/lib/fetchCountryData.ts
@@ -32,11 +32,12 @@ export async function fetchCountryDataForCountry(countryId: number, locale: stri
 
 async function fetchRows(tableId: string, countryId: number, language: string): Promise<CountryDataRecord[]> {
 	const where = `(Country_id,eq,${countryId})~and(Language,eq,${language})`
+	const sort = JSON.stringify([{ direction: 'asc', field: 'Order' }])
 
 	const response = await instance.get<FetchResponseRecords<CountryDataRecord>>(
-		`/data/${process.env.NOCODB_BASE_ID}/${tableId}/records?where=${encodeURIComponent(where)}`,
+		`/data/${process.env.NOCODB_BASE_ID}/${tableId}/records?where=${encodeURIComponent(where)}&sort=${encodeURIComponent(sort)}`,
 		{
-			params: { fields: COUNTRY_DATA_FIELDS, sort: 'Order', pageSize: 100 },
+			params: { fields: COUNTRY_DATA_FIELDS, pageSize: 100 },
 			timeout: 20000
 		}
 	)

--- a/webapp/lib/fetchCountryData.ts
+++ b/webapp/lib/fetchCountryData.ts
@@ -36,7 +36,7 @@ async function fetchRows(tableId: string, countryId: number, language: string): 
 	const response = await instance.get<FetchResponseRecords<CountryDataRecord>>(
 		`/data/${process.env.NOCODB_BASE_ID}/${tableId}/records?where=${encodeURIComponent(where)}`,
 		{
-			params: { fields: COUNTRY_DATA_FIELDS, sort: 'Order' },
+			params: { fields: COUNTRY_DATA_FIELDS, sort: 'Order', pageSize: 100 },
 			timeout: 20000
 		}
 	)

--- a/webapp/lib/fetchCountryData.ts
+++ b/webapp/lib/fetchCountryData.ts
@@ -6,7 +6,7 @@ const COUNTRY_DATA_FIELDS = 'Id,Type,Order,Title,Content'
 
 /**
  * Fetch all CountryData rows for a given Country_id and locale (Language).
- * Falls back to 'en' if no rows are found for the requested locale.
+ * Only returns rows for the requested locale — no fallback.
  */
 export async function fetchCountryDataForCountry(countryId: number, locale: string): Promise<CountryDataRecord[]> {
 	try {
@@ -16,14 +16,7 @@ export async function fetchCountryDataForCountry(countryId: number, locale: stri
 			return []
 		}
 
-		const rows = await fetchRows(tableId, countryId, locale)
-
-		// Fall back to 'en' if the requested locale returned nothing
-		if (rows.length === 0 && locale !== 'en') {
-			return fetchRows(tableId, countryId, 'en')
-		}
-
-		return rows
+		return await fetchRows(tableId, countryId, locale)
 	} catch (error) {
 		console.error('Error fetching CountryData:', error)
 		return []

--- a/webapp/lib/fetchCountryData.ts
+++ b/webapp/lib/fetchCountryData.ts
@@ -1,12 +1,14 @@
 import type { CountryDataRecord } from '@/types/apiTypes'
+import { fallbackLanguage } from '@/i18n/i18next.config'
 import { getTableIdByName } from './fetchMetaTables'
 import { FetchResponseRecords, instance } from './instance'
 
-const COUNTRY_DATA_FIELDS = 'Id,Type,Order,Title,Content'
+const COUNTRY_DATA_FIELDS = 'Type,Order,Title,Content'
 
 /**
  * Fetch all CountryData rows for a given Country_id and locale (Language).
- * Only returns rows for the requested locale — no fallback.
+ * If the requested locale returns no rows and isn't the fallback language,
+ * retries once with the fallback language (Decision #4 in the plan).
  */
 export async function fetchCountryDataForCountry(countryId: number, locale: string): Promise<CountryDataRecord[]> {
 	try {
@@ -16,7 +18,13 @@ export async function fetchCountryDataForCountry(countryId: number, locale: stri
 			return []
 		}
 
-		return await fetchRows(tableId, countryId, locale)
+		const rows = await fetchRows(tableId, countryId, locale)
+
+		if (rows.length === 0 && locale !== fallbackLanguage) {
+			return await fetchRows(tableId, countryId, fallbackLanguage)
+		}
+
+		return rows
 	} catch (error) {
 		console.error('Error fetching CountryData:', error)
 		return []

--- a/webapp/lib/fetchCountryData.ts
+++ b/webapp/lib/fetchCountryData.ts
@@ -1,0 +1,49 @@
+import type { CountryDataRecord } from '@/types/apiTypes'
+import { getTableIdByName } from './fetchMetaTables'
+import { FetchResponseRecords, instance } from './instance'
+
+const COUNTRY_DATA_FIELDS = 'Id,Type,Order,Title,Content'
+
+/**
+ * Fetch all CountryData rows for a given Country_id and locale (Language).
+ * Falls back to 'en' if no rows are found for the requested locale.
+ */
+export async function fetchCountryDataForCountry(countryId: number, locale: string): Promise<CountryDataRecord[]> {
+	try {
+		const tableId = await getTableIdByName('CountryData')
+
+		if (!tableId) {
+			return []
+		}
+
+		const rows = await fetchRows(tableId, countryId, locale)
+
+		// Fall back to 'en' if the requested locale returned nothing
+		if (rows.length === 0 && locale !== 'en') {
+			return fetchRows(tableId, countryId, 'en')
+		}
+
+		return rows
+	} catch (error) {
+		console.error('Error fetching CountryData:', error)
+		return []
+	}
+}
+
+async function fetchRows(tableId: string, countryId: number, language: string): Promise<CountryDataRecord[]> {
+	const where = `(Country_id,eq,${countryId})~and(Language,eq,${language})`
+
+	const response = await instance.get<FetchResponseRecords<CountryDataRecord>>(
+		`/data/${process.env.NOCODB_BASE_ID}/${tableId}/records?where=${encodeURIComponent(where)}`,
+		{
+			params: { fields: COUNTRY_DATA_FIELDS, sort: 'Order' },
+			timeout: 20000
+		}
+	)
+
+	if (response.status !== 200) {
+		throw new Error(`Failed to fetch CountryData: ${response.statusText}`)
+	}
+
+	return response.data.records ?? []
+}

--- a/webapp/lib/fetchCountryData.ts
+++ b/webapp/lib/fetchCountryData.ts
@@ -46,5 +46,6 @@ async function fetchRows(tableId: string, countryId: number, language: string): 
 		throw new Error(`Failed to fetch CountryData: ${response.statusText}`)
 	}
 
-	return response.data.records ?? []
+	// Drop rows with no Content — NocoDB stores placeholder rows per Type/Order even when empty
+	return (response.data.records ?? []).filter(r => (r.fields.Content ?? '').trim() !== '')
 }

--- a/webapp/next.config.ts
+++ b/webapp/next.config.ts
@@ -19,6 +19,7 @@ const nextConfig: NextConfig = {
 		remotePatterns: [
 			{ hostname: 'cdn.shadcnstudio.com' },
 			{ hostname: 'noco-uploads.s3.fr-par.scw.cloud' },
+			{ hostname: 'vcm-watch.s3.fr-par.scw.cloud' },
 			{ hostname: 'placehold.co', protocol: 'https' }
 		]
 	}

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -3302,31 +3302,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
-      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
-      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
@@ -6194,6 +6169,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",

--- a/webapp/types/apiTypes.ts
+++ b/webapp/types/apiTypes.ts
@@ -31,6 +31,7 @@ export type TableTitle =
 	| 'PageField'
 	| 'Translation'
 	| 'Country'
+	| 'CountryData'
 	| 'DistributionZone'
 	| 'Map - Tooltip'
 	| 'Municipality'
@@ -207,11 +208,18 @@ export interface CountryDetailFields {
 	Name: string
 	Code: string
 	Geometry: string
-	'PVC Level': string | null
-	'VCM Level': string | null
-	'Distribution Zones'?: unknown
-	Municipalities?: unknown
 	Actors?: unknown
 	Url?: string
 }
 export type CountryDetailRecord = Record<CountryDetailFields>
+
+export type CountryDataType = 'stat' | 'legislation' | 'missing_data'
+
+export interface CountryDataFields {
+	Id: number
+	Type: CountryDataType
+	Order: number
+	Title: string | null
+	Content: string | null
+}
+export type CountryDataRecord = Record<CountryDataFields>

--- a/webapp/types/apiTypes.ts
+++ b/webapp/types/apiTypes.ts
@@ -205,17 +205,17 @@ export interface CountryListFields {
 export type CountryListRecord = Record<CountryListFields>
 
 export interface NocoAttachment {
-	signedPath?: string
-	path?: string
+	url?: string
+	signedUrl?: string
 	title?: string
 	mimetype?: string
 	size?: number
 	width?: number
 	height?: number
 	thumbnails?: {
-		tiny?: { signedPath?: string }
-		small?: { signedPath?: string }
-		card_cover?: { signedPath?: string }
+		tiny?: { signedUrl?: string }
+		small?: { signedUrl?: string }
+		card_cover?: { signedUrl?: string }
 	}
 }
 

--- a/webapp/types/apiTypes.ts
+++ b/webapp/types/apiTypes.ts
@@ -204,12 +204,27 @@ export interface CountryListFields {
 }
 export type CountryListRecord = Record<CountryListFields>
 
+export interface NocoAttachment {
+	signedPath?: string
+	path?: string
+	title?: string
+	mimetype?: string
+	size?: number
+	width?: number
+	height?: number
+	thumbnails?: {
+		tiny?: { signedPath?: string }
+		small?: { signedPath?: string }
+		card_cover?: { signedPath?: string }
+	}
+}
+
 export interface CountryDetailFields {
 	Name: string
 	Code: string
 	Geometry: string
 	Actors?: unknown
-	Url?: string
+	Image?: NocoAttachment[]
 }
 export type CountryDetailRecord = Record<CountryDetailFields>
 

--- a/webapp/types/apiTypes.ts
+++ b/webapp/types/apiTypes.ts
@@ -223,7 +223,6 @@ export interface CountryDetailFields {
 	Name: string
 	Code: string
 	Geometry: string
-	Actors?: unknown
 	Image?: NocoAttachment[]
 }
 export type CountryDetailRecord = Record<CountryDetailFields>
@@ -231,7 +230,6 @@ export type CountryDetailRecord = Record<CountryDetailFields>
 export type CountryDataType = 'stat' | 'legislation' | 'missing_data'
 
 export interface CountryDataFields {
-	Id: number
 	Type: CountryDataType
 	Order: number
 	Title: string | null


### PR DESCRIPTION
Closes #115.

Makes the country-profile detail panel fully dynamic from the NocoDB `CountryData` table instead of hardcoding the "More details" list and "Missing data" cards, and replacing `Country.PVC Level` / `VCM Level` / link counts with translated stat rows.

## Changes

- New `lib/fetchCountryData.ts`: fetches CountryData rows for a Country_id + Language, ordered by `Order`, with explicit pageSize.
- `fetchCountryByCode` now accepts `locale`, returns `{ country, data }`; drops PVC/VCM/zones fields from the requested columns. Falls back to `en` if the locale returns no rows.
- `/api/countries/[code]?locale=xx` whitelists locale and returns the combined payload.
- `CountryProfileDetail` renders stats, legislation (accordion bullet list), missing-data from `CountryData`; hides empty sections.
- `CountryCarousel` / page propagate `locale`.
- Types updated: new `CountryDataFields`/`CountryDataRecord`; removed obsolete detail fields.

## Verification

- `tsc --noEmit`: clean
- `vitest run`: 43/43 pass (6 files)

Plan: `docs/plans/implemented/2026-04-18-country-profile-dynamic.md`