### PR TITLE
Country-level map tooltip (#114)

### DIFF
--- a/webapp/components/MapView.tsx
+++ b/webapp/components/MapView.tsx
@@ -223,30 +223,51 @@ export function MapView() {
 
 	const onMapClick = useCallback(
 		(e: MapLayerMouseEvent) => {
-			const feature = e.features?.find(f => f.layer?.id === DISTRIBUTION_ZONE_PICK_LAYER_ID)
+			// 1. Check for a distribution zone feature first
+			const zoneFeature = e.features?.find(f => f.layer?.id === DISTRIBUTION_ZONE_PICK_LAYER_ID)
 
-			if (!feature?.properties) {
-				closeZoneCard()
+			if (zoneFeature?.properties) {
+				const props = zoneFeature.properties as Record<string, unknown>
+				const name = displayZoneName(props.name)
+				const { lng, lat } = e.lngLat
+				const tooltipPvcRaw = rawTooltipPvcFromFeatureProperties(props)
+				const tooltipVcmRaw = rawTooltipVcmFromFeatureProperties(props)
+				const zoneId = parseDistributionZoneIdFromFeature(zoneFeature)
+
+				console.log('[MapView] click zone', {
+					featureId: zoneFeature.id,
+					zoneId,
+					props
+				})
+
+				setZoneDetailPvcComment(undefined)
+				setZoneDetailAnalyses([])
+				setZoneDetailLoading(true)
+				setZoneCard({ kind: 'zone', lng, lat, name, tooltipPvcRaw, tooltipVcmRaw, zoneId })
 				return
 			}
 
-			const props = feature.properties as Record<string, unknown>
-			const name = displayZoneName(props.name)
-			const { lng, lat } = e.lngLat
-			const tooltipPvcRaw = rawTooltipPvcFromFeatureProperties(props)
-			const tooltipVcmRaw = rawTooltipVcmFromFeatureProperties(props)
-			const zoneId = parseDistributionZoneIdFromFeature(feature)
+			// 2. Fall back to a country feature
+			const countryFeature = e.features?.find(f => f.layer?.id === COUNTRIES_FILL_LAYER_ID)
 
-			console.log('[MapView] click zone', {
-				featureId: feature.id,
-				zoneId,
-				props
-			})
+			if (countryFeature?.properties) {
+				const props = countryFeature.properties as Record<string, unknown>
+				const name = displayZoneName(props.name)
+				const { lng, lat } = e.lngLat
+				const tooltipPvcRaw = rawTooltipPvcFromFeatureProperties(props)
+				const tooltipVcmRaw = rawTooltipVcmFromFeatureProperties(props)
 
-			setZoneDetailPvcComment(undefined)
-			setZoneDetailAnalyses([])
-			setZoneDetailLoading(true)
-			setZoneCard({ lng, lat, name, tooltipPvcRaw, tooltipVcmRaw, zoneId })
+				console.log('[MapView] click country', { props })
+
+				setZoneDetailPvcComment(undefined)
+				setZoneDetailAnalyses([])
+				setZoneDetailLoading(false)
+				setZoneCard({ kind: 'country', lng, lat, name, tooltipPvcRaw, tooltipVcmRaw, zoneId: null })
+				return
+			}
+
+			// 3. Nothing hit — close
+			closeZoneCard()
 		},
 		[closeZoneCard]
 	)
@@ -323,7 +344,7 @@ export function MapView() {
 	}, [zoneCard, closeZoneCard])
 
 	useEffect(() => {
-		if (!zoneCard?.zoneId) {
+		if (!zoneCard?.zoneId || zoneCard.kind !== 'zone') {
 			return
 		}
 

--- a/webapp/components/MapView.tsx
+++ b/webapp/components/MapView.tsx
@@ -18,9 +18,11 @@ import { ROUTES } from '@/routes/routes'
 import { distributionZoneTierFilter, type MapRiskTier } from '@/lib/map/distributionZoneRisk'
 import { createBaseMapStyle, COUNTRIES_FILL_LAYER_ID, MAP_DISTRIBUTION_ZONES_MIN_ZOOM } from '@/lib/map/mapStyle'
 import {
+	pvcCountryTooltipBadgeFromTileProperty,
 	pvcTooltipBadgeFromTileProperty,
 	rawTooltipPvcFromFeatureProperties,
 	rawTooltipVcmFromFeatureProperties,
+	vcmCountryTooltipBadgeFromTileProperty,
 	vcmTooltipBadgeFromTileProperty
 } from '@/lib/map/mapTooltipPvcBadge'
 import { Card, CardContent, CardTitle } from '@/components/ui/card'
@@ -385,9 +387,17 @@ export function MapView() {
 		return () => ac.abort()
 	}, [zoneCard?.zoneId, zoneCard?.kind])
 
-	const zoneCardPvcBadge = zoneCard ? pvcTooltipBadgeFromTileProperty(zoneCard.tooltipPvcRaw) : null
+	const zoneCardPvcBadge = zoneCard
+		? zoneCard.kind === 'country'
+			? pvcCountryTooltipBadgeFromTileProperty(zoneCard.tooltipPvcRaw)
+			: pvcTooltipBadgeFromTileProperty(zoneCard.tooltipPvcRaw)
+		: null
 
-	const zoneCardVcmBadge = zoneCard ? vcmTooltipBadgeFromTileProperty(zoneCard.tooltipVcmRaw) : null
+	const zoneCardVcmBadge = zoneCard
+		? zoneCard.kind === 'country'
+			? vcmCountryTooltipBadgeFromTileProperty(zoneCard.tooltipVcmRaw)
+			: vcmTooltipBadgeFromTileProperty(zoneCard.tooltipVcmRaw)
+		: null
 
 	const zoneCardStyle = useMemo(() => {
 		if (!zoneCardScreen) {

--- a/webapp/components/MapView.tsx
+++ b/webapp/components/MapView.tsx
@@ -463,33 +463,37 @@ export function MapView() {
 											</span>
 										) : null}
 									</div>
-									{zoneDetailPvcComment ? <p className='text-navy-600 text-xs'>{zoneDetailPvcComment}</p> : null}
-									{zoneDetailLoading ? (
-										<div className='flex flex-col gap-1.5 pt-1'>
-											<div className='bg-navy-100 h-3 w-1/3 animate-pulse rounded' />
-											<div className='bg-navy-100 h-2.5 w-3/4 animate-pulse rounded' />
-											<div className='bg-navy-100 h-2.5 w-2/3 animate-pulse rounded' />
-										</div>
-									) : zoneDetailAnalyses.length > 0 ? (
-										<div className='pt-1'>
-											<p className='text-navy-800 text-xs font-semibold'>Top 3 VCM Results</p>
-											<ul className='text-navy-600 mt-1 list-inside list-disc text-xs'>
-												{zoneDetailAnalyses.map((a, i) => (
-													<li key={i}>
-														{formatAnalysisDate(a.date)}
-														{a.vcmMeasure != null ? ` - ${a.vcmMeasure} µg/L` : ''}
-													</li>
-												))}
-											</ul>
-										</div>
-									) : null}
-									{zoneCard.zoneId != null ? (
-										<Link
-											href={`/${locale}${ROUTES.ACT}?zone=${zoneCard.zoneId}`}
-											className='bg-navy-800 hover:bg-navy-700 mt-1 inline-flex items-center justify-center rounded-lg px-4 py-2 text-xs font-medium text-white transition-colors'
-										>
-											Take action !
-										</Link>
+									{zoneCard.kind === 'zone' ? (
+										<>
+											{zoneDetailPvcComment ? <p className='text-navy-600 text-xs'>{zoneDetailPvcComment}</p> : null}
+											{zoneDetailLoading ? (
+												<div className='flex flex-col gap-1.5 pt-1'>
+													<div className='bg-navy-100 h-3 w-1/3 animate-pulse rounded' />
+													<div className='bg-navy-100 h-2.5 w-3/4 animate-pulse rounded' />
+													<div className='bg-navy-100 h-2.5 w-2/3 animate-pulse rounded' />
+												</div>
+											) : zoneDetailAnalyses.length > 0 ? (
+												<div className='pt-1'>
+													<p className='text-navy-800 text-xs font-semibold'>Top 3 VCM Results</p>
+													<ul className='text-navy-600 mt-1 list-inside list-disc text-xs'>
+														{zoneDetailAnalyses.map((a, i) => (
+															<li key={i}>
+																{formatAnalysisDate(a.date)}
+																{a.vcmMeasure != null ? ` - ${a.vcmMeasure} µg/L` : ''}
+															</li>
+														))}
+													</ul>
+												</div>
+											) : null}
+											{zoneCard.zoneId != null ? (
+												<Link
+													href={`/${locale}${ROUTES.ACT}?zone=${zoneCard.zoneId}`}
+													className='bg-navy-800 hover:bg-navy-700 mt-1 inline-flex items-center justify-center rounded-lg px-4 py-2 text-xs font-medium text-white transition-colors'
+												>
+													Take action !
+												</Link>
+											) : null}
+										</>
 									) : null}
 								</CardContent>
 							</Card>

--- a/webapp/components/MapView.tsx
+++ b/webapp/components/MapView.tsx
@@ -16,7 +16,7 @@ import { formatAnalysisDate, type RecentAnalysis } from '@/lib/fetchAnalysesForD
 import useLocale from '@/hooks/useLocale'
 import { ROUTES } from '@/routes/routes'
 import { distributionZoneTierFilter, type MapRiskTier } from '@/lib/map/distributionZoneRisk'
-import { createBaseMapStyle, MAP_DISTRIBUTION_ZONES_MIN_ZOOM } from '@/lib/map/mapStyle'
+import { createBaseMapStyle, COUNTRIES_FILL_LAYER_ID, MAP_DISTRIBUTION_ZONES_MIN_ZOOM } from '@/lib/map/mapStyle'
 import {
 	pvcTooltipBadgeFromTileProperty,
 	rawTooltipPvcFromFeatureProperties,
@@ -248,9 +248,13 @@ export function MapView() {
 	)
 
 	const onMapMouseMove = useCallback((e: MapLayerMouseEvent) => {
-		const overZone = Boolean(e.features?.some(f => f.layer?.id === DISTRIBUTION_ZONE_PICK_LAYER_ID))
+		const overInteractive = Boolean(
+			e.features?.some(
+				f => f.layer?.id === DISTRIBUTION_ZONE_PICK_LAYER_ID || f.layer?.id === COUNTRIES_FILL_LAYER_ID
+			)
+		)
 
-		setMapCursor(overZone ? 'pointer' : '')
+		setMapCursor(overInteractive ? 'pointer' : '')
 	}, [])
 
 	const onMapMove = useCallback((e: ViewStateChangeEvent) => {
@@ -399,7 +403,7 @@ export function MapView() {
 						latitude: MAP_INTRO_VIEW_STATE.latitude,
 						zoom: MAP_INTRO_VIEW_STATE.zoom
 					}}
-					interactiveLayerIds={[DISTRIBUTION_ZONE_PICK_LAYER_ID]}
+					interactiveLayerIds={[DISTRIBUTION_ZONE_PICK_LAYER_ID, COUNTRIES_FILL_LAYER_ID]}
 					mapStyle={mapStyle}
 					style={{ width: '100%', height: '100%' }}
 					onClick={onMapClick}

--- a/webapp/components/MapView.tsx
+++ b/webapp/components/MapView.tsx
@@ -52,14 +52,18 @@ function emptyMapMoveSubscriptionCleanup() {
 	/* not subscribed */
 }
 
-interface ZoneCardState {
+interface MapCardState {
+	kind: 'zone' | 'country'
 	lng: number
 	lat: number
 	name: string
 	tooltipPvcRaw: string | null
 	tooltipVcmRaw: string | null
-	zoneId: number | null
+	zoneId: number | null // only meaningful when kind === 'zone'
 }
+
+/** @deprecated use MapCardState — kept as alias to minimise churn */
+type ZoneCardState = MapCardState
 
 function parseDistributionZoneIdFromProperties(props: Record<string, unknown>): number | null {
 	const v = props.noco_id ?? props.id ?? props.Id

--- a/webapp/components/MapView.tsx
+++ b/webapp/components/MapView.tsx
@@ -274,9 +274,7 @@ export function MapView() {
 
 	const onMapMouseMove = useCallback((e: MapLayerMouseEvent) => {
 		const overInteractive = Boolean(
-			e.features?.some(
-				f => f.layer?.id === DISTRIBUTION_ZONE_PICK_LAYER_ID || f.layer?.id === COUNTRIES_FILL_LAYER_ID
-			)
+			e.features?.some(f => f.layer?.id === DISTRIBUTION_ZONE_PICK_LAYER_ID || f.layer?.id === COUNTRIES_FILL_LAYER_ID)
 		)
 
 		setMapCursor(overInteractive ? 'pointer' : '')
@@ -385,7 +383,7 @@ export function MapView() {
 		})()
 
 		return () => ac.abort()
-	}, [zoneCard?.zoneId])
+	}, [zoneCard?.zoneId, zoneCard?.kind])
 
 	const zoneCardPvcBadge = zoneCard ? pvcTooltipBadgeFromTileProperty(zoneCard.tooltipPvcRaw) : null
 

--- a/webapp/lib/map/__tests__/mapTooltipBadges.test.ts
+++ b/webapp/lib/map/__tests__/mapTooltipBadges.test.ts
@@ -1,9 +1,11 @@
 import { describe, it, expect } from 'vitest'
 
 import {
+	pvcCountryTooltipBadgeFromTileProperty,
 	pvcTooltipBadgeFromTileProperty,
 	rawTooltipPvcFromFeatureProperties,
 	rawTooltipVcmFromFeatureProperties,
+	vcmCountryTooltipBadgeFromTileProperty,
 	vcmTooltipBadgeFromTileProperty
 } from '../mapTooltipPvcBadge'
 
@@ -84,5 +86,61 @@ describe('rawTooltipVcmFromFeatureProperties', () => {
 
 	it('returns null when missing', () => {
 		expect(rawTooltipVcmFromFeatureProperties({})).toBeNull()
+	})
+})
+
+describe('pvcCountryTooltipBadgeFromTileProperty', () => {
+	it('returns red badge for "known_length"', () => {
+		const badge = pvcCountryTooltipBadgeFromTileProperty('known_length')
+
+		expect(badge).not.toBeNull()
+		expect(badge!.label).toBe('PVC network length known')
+		expect(badge!.style.borderColor).toBe('#dc2626')
+	})
+
+	it('returns gray badge for "unknown_length"', () => {
+		const badge = pvcCountryTooltipBadgeFromTileProperty('unknown_length')
+
+		expect(badge).not.toBeNull()
+		expect(badge!.label).toBe('PVC network length unknown')
+		expect(badge!.style.borderColor).toBe('#64748b')
+	})
+
+	it('returns null for null/empty/zone-style values', () => {
+		expect(pvcCountryTooltipBadgeFromTileProperty(null)).toBeNull()
+		expect(pvcCountryTooltipBadgeFromTileProperty('')).toBeNull()
+		expect(pvcCountryTooltipBadgeFromTileProperty('No PVC')).toBeNull()
+	})
+})
+
+describe('vcmCountryTooltipBadgeFromTileProperty', () => {
+	it('returns gray badge for "unknown"', () => {
+		const badge = vcmCountryTooltipBadgeFromTileProperty('unknown')
+
+		expect(badge).not.toBeNull()
+		expect(badge!.label).toBe('No VCM data')
+		expect(badge!.style.borderColor).toBe('#64748b')
+	})
+
+	it('returns orange badge for "confirmed_localized_contamination"', () => {
+		const badge = vcmCountryTooltipBadgeFromTileProperty('confirmed_localized_contamination')
+
+		expect(badge).not.toBeNull()
+		expect(badge!.label).toBe('Localized VCM contamination')
+		expect(badge!.style.borderColor).toBe('#ea580c')
+	})
+
+	it('returns red badge for "confirmed_widespread_contamination"', () => {
+		const badge = vcmCountryTooltipBadgeFromTileProperty('confirmed_widespread_contamination')
+
+		expect(badge).not.toBeNull()
+		expect(badge!.label).toBe('Widespread VCM contamination')
+		expect(badge!.style.borderColor).toBe('#dc2626')
+	})
+
+	it('returns null for null/empty/zone-style values', () => {
+		expect(vcmCountryTooltipBadgeFromTileProperty(null)).toBeNull()
+		expect(vcmCountryTooltipBadgeFromTileProperty('')).toBeNull()
+		expect(vcmCountryTooltipBadgeFromTileProperty('> 0.5 mcg/L')).toBeNull()
 	})
 })

--- a/webapp/lib/map/__tests__/mapTooltipBadges.test.ts
+++ b/webapp/lib/map/__tests__/mapTooltipBadges.test.ts
@@ -106,6 +106,14 @@ describe('pvcCountryTooltipBadgeFromTileProperty', () => {
 		expect(badge!.style.borderColor).toBe('#64748b')
 	})
 
+	it('returns gray badge for "unknown"', () => {
+		const badge = pvcCountryTooltipBadgeFromTileProperty('unknown')
+
+		expect(badge).not.toBeNull()
+		expect(badge!.label).toBe('PVC presence unknown')
+		expect(badge!.style.borderColor).toBe('#64748b')
+	})
+
 	it('returns null for null/empty/zone-style values', () => {
 		expect(pvcCountryTooltipBadgeFromTileProperty(null)).toBeNull()
 		expect(pvcCountryTooltipBadgeFromTileProperty('')).toBeNull()
@@ -120,6 +128,14 @@ describe('vcmCountryTooltipBadgeFromTileProperty', () => {
 		expect(badge).not.toBeNull()
 		expect(badge!.label).toBe('No VCM data')
 		expect(badge!.style.borderColor).toBe('#64748b')
+	})
+
+	it('returns yellow badge for "positive_analysis"', () => {
+		const badge = vcmCountryTooltipBadgeFromTileProperty('positive_analysis')
+
+		expect(badge).not.toBeNull()
+		expect(badge!.label).toBe('Positive VCM analysis')
+		expect(badge!.style.borderColor).toBe('#a16207')
 	})
 
 	it('returns orange badge for "confirmed_localized_contamination"', () => {

--- a/webapp/lib/map/mapTooltipPvcBadge.ts
+++ b/webapp/lib/map/mapTooltipPvcBadge.ts
@@ -153,6 +153,10 @@ const COUNTRY_PVC_TOOLTIP_BADGES = buildCaseInsensitiveMap({
 	unknown_length: {
 		label: 'PVC network length unknown',
 		style: tierStyle('inconnu')
+	},
+	unknown: {
+		label: 'PVC presence unknown',
+		style: tierStyle('inconnu')
 	}
 })
 
@@ -160,6 +164,14 @@ const COUNTRY_VCM_TOOLTIP_BADGES = buildCaseInsensitiveMap({
 	unknown: {
 		label: 'No VCM data',
 		style: tierStyle('inconnu')
+	},
+	positive_analysis: {
+		label: 'Positive VCM analysis',
+		style: {
+			borderColor: colorCodeConfig.yellow.border,
+			backgroundColor: colorCodeConfig.yellow.bg,
+			color: colorCodeConfig.yellow.border
+		}
 	},
 	confirmed_localized_contamination: {
 		label: 'Localized VCM contamination',

--- a/webapp/lib/map/mapTooltipPvcBadge.ts
+++ b/webapp/lib/map/mapTooltipPvcBadge.ts
@@ -140,6 +140,69 @@ export function vcmTooltipBadgeFromTileProperty(raw: unknown): PvcTooltipBadge |
 	return { label: cfg.label, style: cfg.style }
 }
 
+// --- Country-level badge configs ---
+//
+// Country PMTiles use a different enum vocabulary than DistributionZone for
+// `pvc_level` / `vcm_level`, aggregated from the Country table in NocoDB.
+
+const COUNTRY_PVC_TOOLTIP_BADGES = buildCaseInsensitiveMap({
+	known_length: {
+		label: 'PVC network length known',
+		style: tierStyle('confirme')
+	},
+	unknown_length: {
+		label: 'PVC network length unknown',
+		style: tierStyle('inconnu')
+	}
+})
+
+const COUNTRY_VCM_TOOLTIP_BADGES = buildCaseInsensitiveMap({
+	unknown: {
+		label: 'No VCM data',
+		style: tierStyle('inconnu')
+	},
+	confirmed_localized_contamination: {
+		label: 'Localized VCM contamination',
+		style: tierStyle('probable')
+	},
+	confirmed_widespread_contamination: {
+		label: 'Widespread VCM contamination',
+		style: tierStyle('confirme')
+	}
+})
+
+export function pvcCountryTooltipBadgeFromTileProperty(raw: unknown): PvcTooltipBadge | null {
+	const key = tilePropertyString(raw)
+
+	if (key === null) {
+		return null
+	}
+
+	const cfg = COUNTRY_PVC_TOOLTIP_BADGES.get(key.toLowerCase())
+
+	if (!cfg) {
+		return null
+	}
+
+	return { label: cfg.label, style: cfg.style }
+}
+
+export function vcmCountryTooltipBadgeFromTileProperty(raw: unknown): PvcTooltipBadge | null {
+	const key = tilePropertyString(raw)
+
+	if (key === null) {
+		return null
+	}
+
+	const cfg = COUNTRY_VCM_TOOLTIP_BADGES.get(key.toLowerCase())
+
+	if (!cfg) {
+		return null
+	}
+
+	return { label: cfg.label, style: cfg.style }
+}
+
 export function rawTooltipVcmFromFeatureProperties(props: Record<string, unknown>): string | null {
 	return tilePropertyString(props.vcm_level)
 }


### PR DESCRIPTION
Closes #114.

Adds a map tooltip when clicking a country, similar to the distribution-zone tooltip but reduced to:

- Country name
- PVC badge
- VCM badge

No PVC comment, no Top 3 VCM analyses, no "Take action" button, no backend fetch.

## Implementation

All changes localised to the frontend:

- `webapp/components/MapView.tsx`
  - `countries-fill` added to `interactiveLayerIds`; pointer cursor on hover for either layer.
  - `zoneCard` state extended with `kind: 'zone' | 'country'` discriminator.
  - `onMapClick` checks zone first, falls back to country, otherwise closes.
  - Detail fetch `useEffect` short-circuits on `kind !== 'zone'`.
  - Country tooltip renders only name + two badges; zone-only content (comment, skeleton, analyses, "Take action") gated on `kind === 'zone'`.
- `webapp/lib/map/mapTooltipPvcBadge.ts`
  - Added `pvcCountryTooltipBadgeFromTileProperty` / `vcmCountryTooltipBadgeFromTileProperty` because country PMTiles use a different vocabulary than distribution zones.

## Country badge vocabulary

**PVC:**
| tile value       | label                       | colour |
|------------------|-----------------------------|--------|
| `known_length`   | PVC network length known    | red    |
| `unknown_length` | PVC network length unknown  | grey   |
| `unknown`        | PVC presence unknown        | grey   |

**VCM:**
| tile value                            | label                        | colour |
|---------------------------------------|------------------------------|--------|
| `unknown`                             | No VCM data                  | grey   |
| `positive_analysis`                   | Positive VCM analysis        | yellow |
| `confirmed_localized_contamination`   | Localized VCM contamination  | orange |
| `confirmed_widespread_contamination`  | Widespread VCM contamination | red    |

## Tests

`npx vitest run` → 5 files / 46 tests pass (7 new cases for the country helpers).

Plan: `docs/plans/2026-04-18-country-tooltip.md`.