### PR TITLE
Add webapp healthcheck for zero-downtime deploys

### DIFF
--- a/docker-compose.deploy.yml
+++ b/docker-compose.deploy.yml
@@ -65,6 +65,12 @@ services:
     volumes:
       - pmtiles-data:/public/pmtiles
       - country-images-data:/public/country-images
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:3000/"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
     labels:
       - 'traefik.http.middlewares.mybasicauth.basicauth.users=vcm:$2y$05$U9xfGncXlz8eRkC6itgtOul/aDhTeHz.qBBXk6hss4xyBbT.cpgn6'
 


### PR DESCRIPTION
Adds a Docker healthcheck on the `webapp` service so Coolify's rolling-update / zero-downtime deploy mode can wait for the new container to be ready before removing the old one.

Uses busybox `wget --spider` (available in the node:24-alpine runtime image) against port 3000.

After merging, enable **Rolling Update / Zero Downtime** in the Coolify app settings.