### PR TITLE
fix: country images hook — remove debounce, add logging, fix cross-device link

### DIFF
--- a/pipelines/export/export_country_images.py
+++ b/pipelines/export/export_country_images.py
@@ -131,9 +131,12 @@ def export_country_images_flow(destination: Path) -> None:
     logger = get_run_logger()
     destination.mkdir(parents=True, exist_ok=True)
 
-    # Stage new images in a sibling temp directory to avoid partial state
+    # Stage new images in a subdirectory of destination (same filesystem) so
+    # os.replace is atomic. Using destination.parent can cross a mount point
+    # in production (e.g. /public vs /public/country-images bind mount) and
+    # raise "Invalid cross-device link" (EXDEV).
     with tempfile.TemporaryDirectory(
-        dir=destination.parent, prefix=".country-images-staging-"
+        dir=destination, prefix=".country-images-staging-"
     ) as tmp_str:
         tmp_dir = Path(tmp_str)
         manifest = download_country_images_task(output_dir=tmp_dir)
@@ -179,9 +182,13 @@ def export_country_images_flow(destination: Path) -> None:
         os.replace(manifest_tmp, destination / "manifest.json")
         logger.info(f"manifest.json updated with {len(manifest)} entries")
 
-        # Remove stale files (old hashes / codes no longer in NocoDB)
+        # Remove stale files (old hashes / codes no longer in NocoDB).
+        # Skip the manifest and any hidden staging directories that live in
+        # the destination (including our own, still open as tmp_dir).
         for existing in list(destination.iterdir()):
             if existing.name == "manifest.json":
+                continue
+            if existing.name.startswith("."):
                 continue
             if existing.name not in new_filenames:
                 existing.unlink()

--- a/pipelines/worker/app.py
+++ b/pipelines/worker/app.py
@@ -49,7 +49,9 @@ _debounce_timer: threading.Timer | None = None
 _search_debounce_lock = threading.Lock()
 _search_debounce_timer: threading.Timer | None = None
 
-# Lock and timer for country images debounce
+# Country images flow runs without debounce (webhook fires rarely and users
+# want to see the new image immediately). A lock still exists for test-suite
+# compatibility but is no longer used to schedule timers.
 _country_images_debounce_lock = threading.Lock()
 _country_images_debounce_timer: threading.Timer | None = None
 
@@ -99,24 +101,27 @@ def _schedule_search_index():
 
 
 def _run_country_images_flow():
-    """Run the country images mirror flow. Called by the debounce timer."""
+    """Run the country images mirror flow in a background thread."""
+    dest = Path(os.environ.get("COUNTRY_IMAGES_DIR", "data/export/country-images"))
+    logger.info("Country images flow: acquiring flow-run lock (destination=%s)", dest)
     with _flow_run_lock:
+        logger.info("Country images flow: starting export")
         try:
-            dest = Path(os.environ.get("COUNTRY_IMAGES_DIR", "data/export/country-images"))
             export_country_images_flow(destination=dest)
+            logger.info("Country images flow: completed successfully")
         except Exception:
             logger.exception("Country images flow failed")
 
 
 def _schedule_country_images():
-    """Schedule (or reschedule) the country images flow after DEBOUNCE_SECONDS."""
-    global _country_images_debounce_timer
-    with _country_images_debounce_lock:
-        if _country_images_debounce_timer is not None:
-            _country_images_debounce_timer.cancel()
-        _country_images_debounce_timer = threading.Timer(DEBOUNCE_SECONDS, _run_country_images_flow)
-        _country_images_debounce_timer.daemon = True
-        _country_images_debounce_timer.start()
+    """Trigger the country images flow immediately in a background thread.
+
+    No debounce: webhook frequency for Country edits is low and users expect
+    the mirror to update promptly after an image change.
+    """
+    logger.info("Country images: dispatching flow run (no debounce)")
+    t = threading.Thread(target=_run_country_images_flow, name="country-images-flow", daemon=True)
+    t.start()
 
 
 @app.get("/health")


### PR DESCRIPTION
## Why

Two issues with the country-images mirror:

1. **Hook not firing.** Reports that updating a Country image in NocoDB did not refresh the mirrored image.
2. **Prod error:**
   ```
   OSError: [Errno 18] Invalid cross-device link:
     '/public/.country-images-staging-scxutpy6/SE.2492a50f.jpg'
     -> '/public/country-images/SE.2492a50f.jpg'
   ```

## Changes

- `pipelines/worker/app.py`: country-images webhook no longer debounces (60s delay was confusing / hid breakage). Flow now dispatches immediately in a background thread, still serialized via `_flow_run_lock`. Added info-level logs at dispatch, lock acquisition, and completion.
- `pipelines/export/export_country_images.py`: staging `TemporaryDirectory` is created **inside** `destination` instead of `destination.parent`. In prod `/public` and `/public/country-images` are different mounts, so `os.replace` across them raised EXDEV. Staging inside destination keeps moves on the same filesystem. Stale-file cleanup now skips dot-prefixed names so the open staging dir isn't touched.

## Tests

`uv run python -m pytest pipelines/worker/test_app.py pipelines/export/tests/test_export_country_images.py` → 26 passed.