### PR TITLE
Add /api/health endpoint and point webapp healthcheck at it

### DIFF
--- a/docker-compose.deploy.yml
+++ b/docker-compose.deploy.yml
@@ -66,11 +66,11 @@ services:
       - pmtiles-data:/public/pmtiles
       - country-images-data:/public/country-images
     healthcheck:
-      test: ["CMD", "wget", "--spider", "-q", "http://localhost:3000/"]
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:3000/api/health"]
       interval: 10s
       timeout: 5s
       retries: 5
-      start_period: 30s
+      start_period: 45s
     labels:
       - 'traefik.http.middlewares.mybasicauth.basicauth.users=vcm:$2y$05$U9xfGncXlz8eRkC6itgtOul/aDhTeHz.qBBXk6hss4xyBbT.cpgn6'
 

--- a/webapp/app/api/health/route.ts
+++ b/webapp/app/api/health/route.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from 'next/server'
+
+// Lightweight health endpoint used by the Docker healthcheck.
+// Must not depend on NocoDB or other external services.
+export const dynamic = 'force-dynamic'
+
+export function GET() {
+	return NextResponse.json({ status: 'ok' }, { status: 200 })
+}


### PR DESCRIPTION
Root / returns 404 (routing is under [locale]), so the healthcheck
failed and Traefik dropped the container. Use a dedicated 200 endpoint.
