### PR TITLE
Use 127.0.0.1 in webapp healthcheck

### DIFF
--- a/docker-compose.deploy.yml
+++ b/docker-compose.deploy.yml
@@ -66,7 +66,7 @@ services:
       - pmtiles-data:/public/pmtiles
       - country-images-data:/public/country-images
     healthcheck:
-      test: ["CMD", "wget", "--spider", "-q", "http://localhost:3000/api/health"]
+      test: ["CMD", "wget", "--spider", "-q", "http://127.0.0.1:3000/api/health"]
       interval: 10s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
busybox wget resolves localhost to ::1 first, but Next.js binds to
0.0.0.0 (IPv4 only), causing connection refused.
