### PR TITLE
bug | fix country images volume mount in prod

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ A lightweight FastAPI service runs alongside the webapp to handle data pipeline 
 - **NocoDB webhooks** → the worker receives webhook POSTs over the Docker internal network
 - **PMTiles generation** → triggered automatically when Country or DistributionZone records change
 - **Country images mirroring** → triggered on Country changes; downloads NocoDB image attachments to a shared volume so the webapp can serve them from a stable, cache-friendly URL instead of short-lived S3 signed URLs (see `docs/architecture.md` § Country Images)
-- **Shared volumes** → `pmtiles-data` at `/public/pmtiles` and `country-images-data` at `/public/country-images`, both mounted by worker and webapp
+- **Shared volumes** → `pmtiles-data` at `/public/pmtiles` (served by a custom route handler); `country-images-data` mounted at `/public/country-images` on the worker (writer) and at `/app/public/country-images` on the webapp (so Next.js' static file handler serves them)
 - **Webhook URL** (configured in NocoDB): `http://worker:3000/webhooks/nocodb`
 
 To run the exports manually (local dev):

--- a/docker-compose.deploy.yml
+++ b/docker-compose.deploy.yml
@@ -57,14 +57,18 @@ services:
       - NOCODB_URL=${NOCODB_URL:-http://nocodb:8080}
       - NODE_ENV=production
       - PM_TILES_DIR=${PM_TILES_DIR:-/public/pmtiles}
-      - COUNTRY_IMAGES_DIR=${COUNTRY_IMAGES_DIR:-/public/country-images}
+      # Note: country images are served by Next.js' static file handler, so the
+      # volume must land inside the image's public/ directory (/app/public)
+      # rather than at /public like the pmtiles volume (which has its own route
+      # handler). No COUNTRY_IMAGES_DIR env needed for the webapp — the path is
+      # resolved relative to process.cwd() in webapp/lib/countryImage.ts.
       # Limit mem - otherwise it won't build on the Coolify VM
     depends_on:
       - nocodb
     restart: unless-stopped
     volumes:
       - pmtiles-data:/public/pmtiles
-      - country-images-data:/public/country-images
+      - country-images-data:/app/public/country-images
     healthcheck:
       test: ["CMD", "wget", "--spider", "-q", "http://127.0.0.1:3000/api/health"]
       interval: 10s

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -191,7 +191,7 @@ To fix this, country images are mirrored to a shared Docker volume and served fr
 
 **Serving:** Next.js serves the images as plain static assets under `/country-images/...`. The `/api/countries/[code]` BFF route resolves the mirrored URL server-side via `webapp/lib/countryImage.ts`, which reads `manifest.json` with mtime-based cache invalidation (no restart needed when the volume updates). The `CountryProfileDetail` client component receives the resolved URL as a prop and uses `priority` on the `<Image>`.
 
-**Volume layout (prod):** `country-images-data` named volume mounted at `/public/country-images` on both `worker` (read/write) and `webapp` (read).
+**Volume layout (prod):** `country-images-data` named volume, mounted at `/public/country-images` on `worker` (read/write) and at `/app/public/country-images` on `webapp` (read). The webapp mount point must live under `/app/public/` so that Next.js' built-in static file handler serves the images — unlike pmtiles, there is no custom route handler for country images.
 
 **Local dev:** A seed `manifest.json` + images are committed at `webapp/public/country-images/` so `pnpm dev` works without running the pipeline. The directory is excluded from the Docker image via `.dockerignore`; in production the volume mount supplies the live set. Refresh locally with `just pipelines export-country-images`.
 
@@ -236,7 +236,7 @@ All services are defined in `docker-compose.deploy.yml` and deployed via [Coolif
 
 - **Shared volumes:**
   - `pmtiles-data` — mounted into both `webapp` (read) and `worker` (read/write) at `/public/pmtiles`
-  - `country-images-data` — mounted into both `webapp` (read) and `worker` (read/write) at `/public/country-images`
+  - `country-images-data` — mounted at `/public/country-images` on the `worker` (read/write) and at `/app/public/country-images` on the `webapp` (read). The webapp path has to be under `/app/public/` so Next.js' static handler serves the files.
 - **Networking:** Coolify external network for postgres access; all services communicate over the default Docker Compose network
 - **Webhook URL** (configured in NocoDB): `http://worker:3000/webhooks/nocodb`
 - **ETL pipelines** (extract/transform/load): Run manually by developers via `just` commands — not deployed as services

--- a/pipelines/export/README.md
+++ b/pipelines/export/README.md
@@ -61,7 +61,7 @@ named volume that is mounted in two places:
 | Service | Mount path               | Purpose                              |
 |---------|--------------------------|--------------------------------------|
 | worker  | `/public/country-images` | Flow writes images + manifest here   |
-| webapp  | `/public/country-images` | Next.js serves them as static assets |
+| webapp  | `/app/public/country-images` | Next.js serves them as static assets (must be under `/app/public` so the built-in static handler picks them up) |
 
 The webapp reads `manifest.json` once (cached in module scope via
 `webapp/lib/countryImage.ts`) to resolve `code → /country-images/<file>`.


### PR DESCRIPTION
## Problem

In prod, country profile images always showed the placeholder even though the worker was successfully mirroring images to the `country-images-data` volume.

## Root cause

Two mismatches in `docker-compose.deploy.yml`:

1. The webapp mounted the volume at `/public/country-images` (root), but Next.js' built-in static file handler only serves from `/app/public/`. So `/country-images/*.jpg` would 404 even with a correct manifest. (Unlike pmtiles, which has its own route handler at `webapp/app/pmtiles/[...path]/route.ts` that reads `PM_TILES_DIR` directly.)
2. `webapp/lib/countryImage.ts` reads the manifest from `process.cwd()/public/country-images/manifest.json` \u2014 i.e. `/app/public/country-images/manifest.json`. That path is empty in the image (`.dockerignore` excludes the seed dir), and the volume mount didn't land there either, so `loadManifest()` always returned `{}` and `getCountryImageSrc` always returned `null`.

The `COUNTRY_IMAGES_DIR` env var set on the webapp service was never actually read by any webapp code.

## Fix

Move the webapp mount to `/app/public/country-images` so Next.js serves the files and the manifest lookup finds them. Worker mount is unchanged. Drop the unused `COUNTRY_IMAGES_DIR` env from the webapp service. Update README / architecture docs / pipelines export README to reflect the asymmetric mount.

## Test plan

- Deploy to prod, hit a country profile page \u2014 image should render instead of the placeholder.
- Local dev unaffected (seed images still served from `webapp/public/country-images/`).