### PR TITLE
Fix webapp build: Buffer→Uint8Array + add tsc to pre-commit

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -19,3 +19,7 @@ jobs:
         path: ~/.cache/pre-commit
         key: pre-commit|${{ env.PY }}|${{ hashFiles('.pre-commit-config.yaml') }}
     - uses: pre-commit/action@v3.0.0
+      env:
+        # tsc-webapp needs webapp/node_modules which isn't installed in this job.
+        # Type-checking runs in the vitest workflow instead, where deps exist.
+        SKIP: tsc-webapp

--- a/.github/workflows/vitest.yaml
+++ b/.github/workflows/vitest.yaml
@@ -29,3 +29,6 @@ jobs:
       - name: Run tests
         working-directory: webapp
         run: pnpm test
+      - name: Type-check
+        working-directory: webapp
+        run: pnpm exec tsc --noEmit

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,3 +18,9 @@ repos:
         files: ^webapp/
         entry: sh -c "cd webapp && npx lint-staged --no-stash"
         language: system
+      - id: tsc-webapp
+        name: TypeScript type-check (webapp)
+        files: ^webapp/.*\.(ts|tsx)$
+        entry: sh -c "cd webapp && npx tsc --noEmit"
+        language: system
+        pass_filenames: false

--- a/webapp/app/country-images/[...path]/route.ts
+++ b/webapp/app/country-images/[...path]/route.ts
@@ -85,7 +85,7 @@ export async function GET(request: NextRequest): Promise<Response> {
 		return new Response('Not found', { status: 404 })
 	}
 
-	return new Response(buffer, {
+	return new Response(new Uint8Array(buffer), {
 		status: 200,
 		headers: {
 			'Content-Type': getContentType(filePath),


### PR DESCRIPTION
## Problem

`next build` fails after #128 landed on main:

```
./app/country-images/[...path]/route.ts:88:22
Type error: Argument of type 'Buffer<ArrayBufferLike>' is not
assignable to parameter of type 'BodyInit | null | undefined'.
```

`pnpm lint` does **not** run the TypeScript compiler, and `pnpm test`
only type-checks files imported from tests, so the error slipped through
local checks and CI (which runs lint + test but not build).

## Fix

1. Wrap the `Buffer` from `fs.readFile` in `new Uint8Array(...)` before
   passing to `Response`. Same bytes on the wire, but the type is now a
   valid `BodyInit`.
2. Add `npx tsc --noEmit` as a local pre-commit hook (scoped to
   `webapp/**/*.{ts,tsx}` changes) so this class of error is caught
   before push.

## Verification

- `pnpm -C webapp build` → success
- `npx tsc --noEmit` → success
- `pre-commit run --all-files` → all hooks pass including new tsc hook