### PR TITLE
#113 | Adapt table queries from 'Team' to 'Members' in NocoDB

### DIFF
--- a/pipelines/export/export_entity_images.py
+++ b/pipelines/export/export_entity_images.py
@@ -91,7 +91,7 @@ def export_entity_images_task(
     """Download entity images and return a key → filename mapping.
 
     Args:
-        table_name:  NocoDB table to query (e.g. ``"Country"`` or ``"Team"``).
+        table_name:  NocoDB table to query (e.g. ``"Country"`` or ``"Members"``).
         key_field:   Field to use as the image key (e.g. ``"Code"`` or
                      ``"Name"``).
         entity_name: Human-readable name for logging (e.g. ``"country"``).

--- a/pipelines/export/export_team_images.py
+++ b/pipelines/export/export_team_images.py
@@ -20,7 +20,7 @@ def export_team_images():
     """Mirror team member images from NocoDB."""
     export_entity_images_flow(
         entity_name="team",
-        table_name="Team",
+        table_name="Members",
         key_field="Name",
         fields=TEAM_FIELDS,
         slugify=True,

--- a/pipelines/export/tests/test_export_entity_images.py
+++ b/pipelines/export/tests/test_export_entity_images.py
@@ -252,7 +252,7 @@ class TestExportEntityImagesTaskTeam:
         ):
             mock_services.db_helper.return_value = mock_db
             result = export_entity_images_task.fn(
-                table_name="Team",
+                table_name="Members",
                 key_field="Name",
                 entity_name="team",
                 fields=["Id", "Name", "Image"],
@@ -307,7 +307,7 @@ class TestExportEntityImagesTaskTeam:
         ):
             mock_services.db_helper.return_value = mock_db
             manifest = export_entity_images_task.fn(
-                table_name="Team",
+                table_name="Members",
                 key_field="Name",
                 entity_name="team",
                 fields=["Id", "Name", "Image"],
@@ -439,7 +439,7 @@ class TestExportEntityImagesFlow:
             records,
             tmp_path,
             entity_name="team",
-            table_name="Team",
+            table_name="Members",
             key_field="Name",
             fields=["Id", "Name", "Image"],
             slugify=True,

--- a/pipelines/worker/app.py
+++ b/pipelines/worker/app.py
@@ -34,7 +34,7 @@ PMTILES_TRIGGER_TABLES = {"Country", "DistributionZone"}
 
 # Tables whose changes should trigger a country/team images mirror
 COUNTRY_IMAGES_TRIGGER_TABLES = {"Country"}
-TEAM_IMAGES_TRIGGER_TABLES = {"Team"}
+TEAM_IMAGES_TRIGGER_TABLES = {"Members"}
 
 # Tables whose changes should trigger a search index rebuild
 SEARCH_INDEX_TRIGGER_TABLES = {"DistributionZone", "Municipality"}

--- a/pipelines/worker/test_app.py
+++ b/pipelines/worker/test_app.py
@@ -89,13 +89,13 @@ class TestWebhookEndpoint:
         assert "export_country_images" in pipelines
         mock_images.assert_called_once()
 
-    def test_webhook_triggers_team_images_on_team(self, client):
-        """A POST with table=Team triggers the team images flow."""
+    def test_webhook_triggers_team_images_on_members(self, client):
+        """A POST with table=Members triggers the team images flow."""
         with patch("pipelines.worker.app.export_team_images") as mock_images:
             mock_images.return_value = None
             response = client.post(
                 "/webhooks/nocodb",
-                json={"type": "records.after.update", "data": {"table_name": "Team"}},
+                json={"type": "records.after.update", "data": {"table_name": "Members"}},
             )
             time.sleep(0.05)
         assert response.status_code == 202

--- a/webapp/lib/fetchTeam.ts
+++ b/webapp/lib/fetchTeam.ts
@@ -53,10 +53,10 @@ interface NocoDBTeamRecord {
 
 export async function fetchTeam(): Promise<TeamMember[]> {
 	try {
-		const tableId = await getTableIdByName('Team')
+		const tableId = await getTableIdByName('Members')
 
 		if (!tableId) {
-			console.warn('fetchTeam: Team table not found in NocoDB meta')
+			console.warn('fetchTeam: Members table not found in NocoDB meta')
 			return []
 		}
 

--- a/webapp/types/apiTypes.ts
+++ b/webapp/types/apiTypes.ts
@@ -39,7 +39,7 @@ export type TableTitle =
 	| 'Contribution'
 	| 'Volunteer'
 	| 'LetterTemplate'
-	| 'Team'
+	| 'Members'
 
 export interface MetaTable {
 	id: string


### PR DESCRIPTION
Renames NocoDB table references from 'Team' to 'Members' in queries and configurations.

- Update TypeScript type definition in apiTypes.ts
- Update table name in WebApp query (fetchTeam.ts)
- Update pipeline trigger configuration (worker/app.py)
- Update pipeline export query (export_team_images.py)
- Update tests for both worker and export pipelines