### PR TITLE
#113 | Drop Prefect decorators from webhook-triggered pipelines

### DIFF
--- a/pipelines/conftest.py
+++ b/pipelines/conftest.py
@@ -5,6 +5,20 @@ from pathlib import Path
 import pytest
 
 
+def pytest_unconfigure(config):
+    """Silence Prefect's atexit log emission.
+
+    Prefect's ephemeral server shuts down at interpreter exit and its
+    PrefectConsoleHandler writes to a rich Console whose underlying stream
+    pytest has already closed, producing a noisy 'Logging error' + traceback
+    after the test summary. Neutralising the prefect logger at teardown
+    suppresses the noise without affecting any test output.
+    """
+    logging.getLogger("prefect").handlers.clear()
+    logging.getLogger("prefect").addHandler(logging.NullHandler())
+    logging.getLogger("prefect").propagate = False
+
+
 @pytest.fixture
 def project_root():
     """Return the project root directory."""

--- a/pipelines/export/export_entity_images.py
+++ b/pipelines/export/export_entity_images.py
@@ -1,5 +1,5 @@
 """
-Generic Prefect workflow to mirror NocoDB entity images to a shared directory.
+Generic pipeline to mirror NocoDB entity images to a shared directory.
 
 Entity images in NocoDB are stored as S3 attachments with short-lived signed
 URLs.  This flow downloads each entity's first image, names it with a

--- a/pipelines/export/export_entity_images.py
+++ b/pipelines/export/export_entity_images.py
@@ -28,6 +28,7 @@ The manifest is written last so readers always see a consistent state.
 
 import hashlib
 import json
+import logging
 import mimetypes
 import os
 import re
@@ -36,10 +37,10 @@ import unicodedata
 from pathlib import Path
 
 import httpx
-from prefect import flow, get_run_logger, task
-from prefect.cache_policies import NO_CACHE
 
 from pipelines.common import services
+
+logger = logging.getLogger(__name__)
 
 
 def _ext_from_mimetype(mime: str | None) -> str:
@@ -79,7 +80,6 @@ def _slugify(value: str) -> str:
     return dashed.strip("-")
 
 
-@task(name="download_entity_images", cache_policy=NO_CACHE)
 def export_entity_images_task(
     table_name: str,
     key_field: str,
@@ -108,7 +108,6 @@ def export_entity_images_task(
         A dict mapping the key (or slug) to the filename written inside
         *output_dir*.
     """
-    logger = get_run_logger()
     db_helper = services.db_helper()
 
     records = db_helper.load_all_records(table_name=table_name, fields=fields)
@@ -198,7 +197,6 @@ def export_entity_images_task(
     return manifest
 
 
-@flow(name="export_entity_images", persist_result=False)
 def export_entity_images_flow(
     entity_name: str,
     table_name: str,
@@ -224,8 +222,6 @@ def export_entity_images_flow(
         fields:       Field names to fetch from NocoDB.
         slugify:      Whether to slugify the key value for filenames.
     """
-    logger = get_run_logger()
-
     images_dir = Path(
         os.environ.get("EXPORT_IMAGES_DIR", "data/export/images")
     )

--- a/pipelines/export/export_pmtiles.py
+++ b/pipelines/export/export_pmtiles.py
@@ -14,16 +14,16 @@ Output GeoJSON fields per feature:
 """
 
 import json
+import logging
 import os
 import shutil
 import subprocess
 import tempfile
 from pathlib import Path
 
-from prefect import flow, get_run_logger, task
-from prefect.cache_policies import NO_CACHE
-
 from pipelines.common import services
+
+logger = logging.getLogger(__name__)
 
 ZONE_FIELDS = ["Id", "Code", "Name", "Geometry", "PVC Level", "VCM Level", "Map Color"]
 # Extra fields per table (e.g. linked record display values)
@@ -34,13 +34,11 @@ ZONE_TABLES = {
 }
 
 
-@task(name="export_zones_geojson", cache_policy=NO_CACHE)
 def export_zones_geojson_task(table_name: str, output_dir: Path) -> Path:
     """
     Read all records from a zone table and write a GeoJSON FeatureCollection.
     Records without geometry are skipped.
     """
-    logger = get_run_logger()
     db_helper = services.db_helper()
 
     fields = ZONE_FIELDS + EXTRA_FIELDS.get(table_name, [])
@@ -90,10 +88,8 @@ def export_zones_geojson_task(table_name: str, output_dir: Path) -> Path:
     return output_path
 
 
-@task(name="create_pmtiles", cache_policy=NO_CACHE)
 def create_pmtiles_task(geojson_file: Path, layer: str, output_dir: Path) -> Path:
     """Convert a GeoJSON file to a PMTiles archive using tippecanoe."""
-    logger = get_run_logger()
     output_dir.mkdir(parents=True, exist_ok=True)
     pmtiles_file = output_dir / f"{layer}.pmtiles"
 
@@ -123,7 +119,6 @@ def create_pmtiles_task(geojson_file: Path, layer: str, output_dir: Path) -> Pat
     return pmtiles_file
 
 
-@flow(name="export_pmtiles", persist_result=False)
 def export_pmtiles_flow(destination: Path) -> None:
     """Export zone data from NocoDB to PMTiles.
 

--- a/pipelines/export/export_pmtiles.py
+++ b/pipelines/export/export_pmtiles.py
@@ -1,5 +1,5 @@
 """
-Prefect workflow to export zone data from NocoDB as PMTiles.
+Export zone data from NocoDB as PMTiles.
 
 Reads zone records (Country, DistributionZone) from NocoDB, produces a GeoJSON
 FeatureCollection per table in a staging directory, then converts them to PMTiles

--- a/pipelines/export/tests/test_export_entity_images.py
+++ b/pipelines/export/tests/test_export_entity_images.py
@@ -106,7 +106,7 @@ class TestExportEntityImagesTaskCountry:
             patch("httpx.get", return_value=mock_response),
         ):
             mock_services.db_helper.return_value = mock_db
-            result = export_entity_images_task.fn(
+            result = export_entity_images_task(
                 table_name="Country",
                 key_field="Code",
                 entity_name="country",
@@ -206,7 +206,7 @@ class TestExportEntityImagesTaskCountry:
             patch("httpx.get", side_effect=fake_get),
         ):
             mock_services.db_helper.return_value = mock_db
-            manifest = export_entity_images_task.fn(
+            manifest = export_entity_images_task(
                 table_name="Country",
                 key_field="Code",
                 entity_name="country",
@@ -251,7 +251,7 @@ class TestExportEntityImagesTaskTeam:
             patch("httpx.get", return_value=mock_response),
         ):
             mock_services.db_helper.return_value = mock_db
-            result = export_entity_images_task.fn(
+            result = export_entity_images_task(
                 table_name="Members",
                 key_field="Name",
                 entity_name="team",
@@ -306,7 +306,7 @@ class TestExportEntityImagesTaskTeam:
             patch("httpx.get", side_effect=fake_get),
         ):
             mock_services.db_helper.return_value = mock_db
-            manifest = export_entity_images_task.fn(
+            manifest = export_entity_images_task(
                 table_name="Members",
                 key_field="Name",
                 entity_name="team",

--- a/pipelines/export/tests/test_export_pmtiles.py
+++ b/pipelines/export/tests/test_export_pmtiles.py
@@ -37,7 +37,7 @@ class TestExportZonesGeojson:
         with patch("pipelines.export.export_pmtiles.services") as mock_services:
             mock_services.db_helper.return_value = mock_db
 
-            path = export_zones_geojson_task.fn(
+            path = export_zones_geojson_task(
                 table_name="Country", output_dir=tmp_path
             )
 
@@ -77,7 +77,7 @@ class TestExportZonesGeojson:
         with patch("pipelines.export.export_pmtiles.services") as mock_services:
             mock_services.db_helper.return_value = mock_db
 
-            path = export_zones_geojson_task.fn(
+            path = export_zones_geojson_task(
                 table_name="DistributionZone", output_dir=tmp_path
             )
 
@@ -101,7 +101,7 @@ class TestExportZonesGeojson:
         with patch("pipelines.export.export_pmtiles.services") as mock_services:
             mock_services.db_helper.return_value = mock_db
 
-            path = export_zones_geojson_task.fn(
+            path = export_zones_geojson_task(
                 table_name="Country", output_dir=tmp_path
             )
 
@@ -140,7 +140,7 @@ class TestCreatePmtiles:
         geojson_file.write_text(json.dumps(_sample_geojson()))
         output_dir = tmp_path / "output"
 
-        result = create_pmtiles_task.fn(
+        result = create_pmtiles_task(
             geojson_file=geojson_file, layer="data_countries", output_dir=output_dir,
         )
 
@@ -153,7 +153,7 @@ class TestCreatePmtiles:
         geojson_file.write_text(json.dumps(_sample_geojson()))
         output_dir = tmp_path / "nested" / "deep" / "output"
 
-        result = create_pmtiles_task.fn(
+        result = create_pmtiles_task(
             geojson_file=geojson_file, layer="test_layer", output_dir=output_dir,
         )
 
@@ -165,10 +165,10 @@ class TestCreatePmtiles:
         geojson_file.write_text(json.dumps(_sample_geojson()))
         output_dir = tmp_path / "output"
 
-        create_pmtiles_task.fn(
+        create_pmtiles_task(
             geojson_file=geojson_file, layer="data_countries", output_dir=output_dir
         )
-        result = create_pmtiles_task.fn(
+        result = create_pmtiles_task(
             geojson_file=geojson_file, layer="data_countries", output_dir=output_dir
         )
 
@@ -180,6 +180,6 @@ class TestCreatePmtiles:
         output_dir = tmp_path / "output"
 
         with pytest.raises(subprocess.CalledProcessError):
-            create_pmtiles_task.fn(
+            create_pmtiles_task(
                 geojson_file=bad_file, layer="bad_layer", output_dir=output_dir
             )

--- a/pipelines/tasks/build_search_index.py
+++ b/pipelines/tasks/build_search_index.py
@@ -1,5 +1,5 @@
 """
-Prefect workflow for building a SearchIndex field on DistributionZone records.
+Build a SearchIndex field on DistributionZone records.
 The SearchIndex concatenates zone name, municipality names (from the zone's
 Municipalities link), and actor names to enable search across all three.
 """

--- a/pipelines/tasks/build_search_index.py
+++ b/pipelines/tasks/build_search_index.py
@@ -4,8 +4,6 @@ The SearchIndex concatenates zone name, municipality names (from the zone's
 Municipalities link), and actor names to enable search across all three.
 """
 
-from prefect import flow, task
-from prefect.cache_policies import NO_CACHE
 from pipelines.common import services
 
 
@@ -31,7 +29,6 @@ def _linked_record_ids(links) -> list[int]:
     return ids
 
 
-@task(name="build_search_index", cache_policy=NO_CACHE)
 def build_search_index_task(db_helper):
     """
     Build a SearchIndex text field for each DistributionZone by combining
@@ -79,7 +76,6 @@ def build_search_index_task(db_helper):
     return len(updates)
 
 
-@flow(name="build_search_index")
 def build_search_index():
     db = services.db_helper()
     count = build_search_index_task(db)


### PR DESCRIPTION
## Summary

Fixes the production worker errors where webhook-triggered flows failed with `Timed out while attempting to connect to ephemeral Prefect API server` and `[Errno 98] address already in use`.

Root cause: every `@flow(...)` call in the worker spun up a fresh Prefect ephemeral uvicorn server. Back-to-back flows raced on ports still in TIME_WAIT, and startup occasionally exceeded the 10s healthcheck on the Coolify VM.

These three pipelines got zero value from Prefect (no caching, no retries, no scheduling, `persist_result=False`) — they only used it for logging. Dropped `@flow` / `@task` decorators entirely, replaced `get_run_logger()` with stdlib `logging.getLogger(__name__)`.

ETL pipelines (`extract/`, `load/`, `transform/`, `calculate_distribution_zone`, `clean_blank_actors`) keep Prefect — they legitimately use caching and `rate_limit`.

## Changes

- `pipelines/export/export_entity_images.py`: drop `@flow` / `@task`, stdlib logging
- `pipelines/export/export_pmtiles.py`: drop `@flow` / `@task`, stdlib logging
- `pipelines/tasks/build_search_index.py`: drop `@flow` / `@task`
- tests: call task functions directly instead of `.fn(...)`
- `pipelines/conftest.py`: silence Prefect atexit logging noise that spams tracebacks after the test summary

Worker import graph verified Prefect-free:
```
Prefect modules loaded by worker: []
types: function function function
```

## Test Plan

- [x] `uv run pytest pipelines/` — 111 passed, no logging errors
- [ ] Deploy to prod, trigger a Country image change in NocoDB, confirm worker log shows stdlib logger output (no `Starting temporary server on http://127.0.0.1:...`)
- [ ] Trigger near-simultaneous Country + DistributionZone edits; confirm both complete without `Errno 98`

## Plan

`docs/plans/2026-04-21-drop-prefect-decorators-webhook-pipelines.md`