### PR TITLE
fix: team page empty in prod (SubTeam → Squad)

### DIFF
--- a/webapp/lib/__tests__/fetchTeam.test.ts
+++ b/webapp/lib/__tests__/fetchTeam.test.ts
@@ -38,7 +38,7 @@ function makeRow(
 		Name: string | null
 		Expertise: string | null
 		City: string | null
-		SubTeam: string | null
+		Squad: string | null
 		nc_order: number | null
 	}> = {}
 ) {
@@ -51,7 +51,7 @@ function makeRow(
 			Expertise: 'Hydrology',
 			City: 'Paris',
 			Image: null,
-			SubTeam: 'project',
+			Squad: 'project',
 			nc_order: 1,
 			...fieldOverrides
 		}

--- a/webapp/lib/fetchTeam.ts
+++ b/webapp/lib/fetchTeam.ts
@@ -10,7 +10,7 @@ import { getTableIdByName } from './fetchMetaTables'
 import { instance } from './instance'
 import type { FetchResponseRecords } from './instance'
 
-const TEAM_FIELDS = 'Id,Name,Expertise,City,Image,SubTeam,nc_order'
+const TEAM_FIELDS = 'Id,Name,Expertise,City,Image,Squad,nc_order'
 
 interface NocoDBTeamRowFields {
 	Id: number
@@ -18,7 +18,7 @@ interface NocoDBTeamRowFields {
 	Expertise: string | null
 	City: string | null
 	Image: unknown
-	SubTeam: string | null
+	Squad: string | null
 	nc_order: number | null
 }
 
@@ -91,7 +91,7 @@ export async function fetchTeam(): Promise<TeamMember[]> {
 					name: fields.Name,
 					role: fields.Expertise ?? '',
 					city: fields.City ?? null,
-					subTeam: fields.SubTeam ?? null,
+					subTeam: fields.Squad ?? null,
 					imageSrc: getEntityImageSrc('team', slug)
 				}
 			})


### PR DESCRIPTION
## Problem
Team section on https://vcm-watch.eu/en/about renders empty in prod.

## Cause
Prod NocoDB `Members` table field is named `Squad`, but `fetchTeam.ts` requested `SubTeam`. The v3 API responds with `422 ERR_FIELD_NOT_FOUND`, which is swallowed by the try/catch and returns `[]`.

## Fix
Rename `SubTeam` → `Squad` in `webapp/lib/fetchTeam.ts` (field list, type, mapping) and in the test fixture.

Tests + type-check pass.