### PR TITLE
#53 | Connect Resources page to NocoDB Ressources table

### DIFF
--- a/webapp/app/[locale]/resources/components/ResourceCard.tsx
+++ b/webapp/app/[locale]/resources/components/ResourceCard.tsx
@@ -1,52 +1,87 @@
-import Link from 'next/link'
-
 import { ArrowUpRight } from 'lucide-react'
 
-export type ResourceType = 'guide' | 'report' | 'template' | 'factsheet' | 'video'
-
 export interface ResourceCardProps {
-	type: ResourceType
+	typeKey: string | null
 	title: string
 	description: string
-	actionLabel: string
 	actionUrl: string
+	actionLabel?: string
 }
 
-const TYPE_CONFIG: Record<ResourceType, { label: string; className: string }> = {
+const TYPE_CONFIG: Record<string, { label: string; className: string; actionLabel: string }> = {
+	'institutional-report': {
+		label: 'Institutional report',
+		className: 'bg-blue-100 text-blue-800 border-blue-200',
+		actionLabel: 'View report'
+	},
+	'research-paper': {
+		label: 'Research paper',
+		className: 'bg-teal-100 text-teal-800 border-teal-200',
+		actionLabel: 'Read paper'
+	},
+	'news-item': {
+		label: 'News',
+		className: 'bg-orange-100 text-orange-800 border-orange-200',
+		actionLabel: 'Read article'
+	},
 	guide: {
 		label: 'Guide',
-		className: 'bg-green-100 text-green-800 border-green-200'
-	},
-	report: {
-		label: 'Report',
-		className: 'bg-blue-100 text-blue-800 border-blue-200'
+		className: 'bg-green-100 text-green-800 border-green-200',
+		actionLabel: 'Read guide'
 	},
 	template: {
 		label: 'Template',
-		className: 'bg-orange-100 text-orange-800 border-orange-200'
+		className: 'bg-orange-100 text-orange-800 border-orange-200',
+		actionLabel: 'Download template'
 	},
 	factsheet: {
 		label: 'Fact sheet',
-		className: 'bg-teal-100 text-teal-800 border-teal-200'
+		className: 'bg-teal-100 text-teal-800 border-teal-200',
+		actionLabel: 'View fact sheet'
 	},
 	video: {
 		label: 'Video',
-		className: 'bg-red-100 text-red-800 border-red-200'
+		className: 'bg-red-100 text-red-800 border-red-200',
+		actionLabel: 'Watch video'
 	}
 }
 
-// TODO: when real URLs are used, add an `external` boolean prop (or detect via URL) to apply
-// target="_blank" rel="noopener noreferrer" on external links.
-export default function ResourceCard({ type, title, description, actionLabel, actionUrl }: ResourceCardProps) {
-	const config = TYPE_CONFIG[type]
+const DEFAULT_CONFIG = {
+	className: 'bg-gray-100 text-gray-800 border-gray-200',
+	actionLabel: 'Open resource'
+}
+
+function titleCase(slug: string): string {
+	return slug.replace(/[-_]+/g, ' ').replace(/\b\w/g, c => c.toUpperCase())
+}
+
+function resolveType(key: string | null): {
+	label: string
+	className: string
+	actionLabel: string
+} {
+	if (!key) {
+		return { label: 'Resource', ...DEFAULT_CONFIG }
+	}
+
+	const hit = TYPE_CONFIG[key]
+
+	if (hit) {
+		return hit
+	}
+
+	return { label: titleCase(key), ...DEFAULT_CONFIG }
+}
+
+export default function ResourceCard({ typeKey, title, description, actionUrl, actionLabel }: ResourceCardProps) {
+	const config = resolveType(typeKey)
+	const linkText = actionLabel ?? config.actionLabel
 
 	return (
 		<div className='flex h-full flex-col rounded-sm bg-white p-10 shadow-xs'>
 			{/* Tag badge */}
 			<div className='mb-3'>
-				<span
-					className={`inline-block rounded border px-2.5 py-0.5 text-xs font-semibold capitalize ${config.className}`}
-				>
+				<span className={`inline-block rounded border px-2.5 py-0.5 text-xs font-semibold ${config.className}`}>
 					{config.label}
 				</span>
 			</div>
@@ -57,15 +92,17 @@ export default function ResourceCard({ type, title, description, actionLabel, ac
 			{/* Description */}
 			<p className='text-navy-600 mb-4 flex-1 text-sm leading-relaxed'>{description}</p>
 
-			{/* Action link */}
+			{/* Action link (external) */}
 			<div className='mt-auto flex justify-end'>
-				<Link
+				<a
 					href={actionUrl}
+					target='_blank'
+					rel='noopener noreferrer'
 					className='text-navy-700 hover:text-navy-900 inline-flex items-center gap-1 text-sm font-medium underline-offset-2 hover:underline'
 				>
-					{actionLabel}
+					{linkText}
 					<ArrowUpRight className='h-4 w-4' />
-				</Link>
+				</a>
 			</div>
 		</div>
 	)

--- a/webapp/app/[locale]/resources/components/ResourcesSection.tsx
+++ b/webapp/app/[locale]/resources/components/ResourcesSection.tsx
@@ -1,69 +1,12 @@
-import ResourceCard, { type ResourceCardProps } from './ResourceCard'
+import { RessourcesRecord } from '@/types/apiTypes'
 import CtaBanner from './CtaBanner'
+import ResourceCard from './ResourceCard'
 
-interface MockResource extends ResourceCardProps {
-	id: string
+interface ResourcesSectionProps {
+	resources: RessourcesRecord[]
 }
 
-const MOCK_RESOURCES: MockResource[] = [
-	{
-		id: 'citizen-guide-water-quality',
-		type: 'guide',
-		title: 'Citizen Guide to Water Quality Testing',
-		description:
-			'A step-by-step guide for residents who want to collect water samples and understand laboratory results related to VCM contamination.',
-		actionLabel: 'Read guide',
-		actionUrl: '#'
-	},
-	{
-		id: 'european-pvc-pipe-report-2023',
-		type: 'report',
-		title: 'European PVC Pipe Infrastructure Report 2023',
-		description:
-			'An overview of PVC water distribution pipes installed across Europe in the 1970s–80s, with maps of known contamination hotspots.',
-		actionLabel: 'View report',
-		actionUrl: '#'
-	},
-	{
-		id: 'request-water-quality-data',
-		type: 'guide',
-		title: 'How to Request Water Quality Data from Authorities',
-		description:
-			'Know your rights. This guide explains the legal frameworks in EU countries that entitle citizens to access official water quality records.',
-		actionLabel: 'Read guide',
-		actionUrl: '#'
-	},
-	{
-		id: 'letter-template-water-provider',
-		type: 'template',
-		title: 'Letter Template: Request to Water Provider',
-		description:
-			'A ready-to-use letter template to formally request VCM contamination data from your local water utility or municipal authority.',
-		actionLabel: 'Download template',
-		actionUrl: '#'
-	},
-	{
-		id: 'vcm-health-risks-factsheet',
-		type: 'factsheet',
-		title: 'VCM Health Risks – Key Facts',
-		description:
-			'A concise fact sheet summarising the established health risks associated with vinyl chloride monomer (VCM) exposure through drinking water.',
-		actionLabel: 'View fact sheet',
-		actionUrl: '#'
-	},
-	{
-		id: 'pvc-pipe-degradation-webinar',
-		type: 'video',
-		title: 'Understanding PVC Pipe Degradation (Webinar)',
-		description:
-			'A recorded webinar by water chemistry experts explaining how PVC pipes degrade over time and how VCM can leach into drinking water.',
-		actionLabel: 'Watch video',
-		actionUrl: '#'
-	}
-]
-
-// TODO: i18n — MOCK_RESOURCES is hardcoded in English; extract for translation when i18n is added
-export default function ResourcesSection() {
+export default function ResourcesSection({ resources }: ResourcesSectionProps) {
 	return (
 		<div>
 			{/* Section header */}
@@ -74,12 +17,19 @@ export default function ResourcesSection() {
 				</p>
 			</div>
 
-			{/* 3-column grid */}
-			<div className='grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3'>
-				{MOCK_RESOURCES.map(resource => (
-					<ResourceCard key={resource.id} {...resource} />
-				))}
-			</div>
+			{resources.length > 0 && (
+				<div className='grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3'>
+					{resources.map(r => (
+						<ResourceCard
+							key={r.id}
+							typeKey={r.fields.Type ?? null}
+							title={r.fields.Title}
+							description={r.fields.Short_Description ?? ''}
+							actionUrl={r.fields.URL ?? '#'}
+						/>
+					))}
+				</div>
+			)}
 
 			{/* CTA banner */}
 			<div className='mt-8'>

--- a/webapp/app/[locale]/resources/components/ResourcesSection.tsx
+++ b/webapp/app/[locale]/resources/components/ResourcesSection.tsx
@@ -24,7 +24,7 @@ export default function ResourcesSection({ resources }: ResourcesSectionProps) {
 							key={r.id}
 							typeKey={r.fields.Type ?? null}
 							title={r.fields.Title}
-							description={r.fields.Short_Description ?? ''}
+							description={r.fields['Short Description'] ?? ''}
 							actionUrl={r.fields.URL ?? '#'}
 						/>
 					))}

--- a/webapp/app/[locale]/resources/page.tsx
+++ b/webapp/app/[locale]/resources/page.tsx
@@ -1,8 +1,12 @@
+import { fetchRessources } from '@/lib/fetchRessources'
 import MethodologySection from './components/MethodologySection'
 import ResourcesSection from './components/ResourcesSection'
 import ResourceTabNav from './components/ResourceTabNav'
 
-export default function ResourcesPage() {
+export default async function ResourcesPage({ params }: { params: Promise<{ locale: string }> }) {
+	const { locale } = await params
+	const resources = await fetchRessources({ locale })
+
 	return (
 		<main className='bg-gray-50'>
 			<ResourceTabNav />
@@ -11,7 +15,7 @@ export default function ResourcesPage() {
 				<div className='mt-12 space-y-16'>
 					{/* Resources section */}
 					<section id='resources' className='scroll-mt-[148px]'>
-						<ResourcesSection />
+						<ResourcesSection resources={resources} />
 					</section>
 
 					<hr className='border-navy-200' />

--- a/webapp/lib/fetchRessources.ts
+++ b/webapp/lib/fetchRessources.ts
@@ -1,0 +1,31 @@
+import { RessourcesRecord } from '@/types/apiTypes'
+import { getTableIdByName } from './fetchMetaTables'
+import { FetchResponseRecords, instance } from './instance'
+
+export async function fetchRessources({ locale }: { locale: string }): Promise<RessourcesRecord[]> {
+	try {
+		const tableId = await getTableIdByName('Ressources')
+
+		if (!tableId) {
+			console.warn('fetchRessources: Ressources table not found in NocoDB meta')
+			return []
+		}
+
+		const where = `(Language,eq,${locale})`
+		const sort = JSON.stringify([{ field: 'nc_order', direction: 'asc' }])
+
+		const res = await instance.get<FetchResponseRecords<RessourcesRecord>>(
+			`/data/${process.env.NOCODB_BASE_ID}/${tableId}/records`,
+			{ params: { where, sort } }
+		)
+
+		if (res.status !== 200) {
+			throw new Error(res.statusText)
+		}
+
+		return res.data.records ?? []
+	} catch (e) {
+		console.error('Error fetching ressources:', e)
+		return []
+	}
+}

--- a/webapp/types/apiTypes.ts
+++ b/webapp/types/apiTypes.ts
@@ -39,6 +39,7 @@ export type TableTitle =
 	| 'Volunteer'
 	| 'LetterTemplate'
 	| 'Members'
+	| 'Ressources'
 
 export interface MetaTable {
 	id: string
@@ -74,6 +75,16 @@ export interface Record<T> {
 }
 
 export type BlogPostRecord = Record<BlogPostFields>
+
+export type RessourcesRecord = Record<RessourcesFields>
+
+export interface RessourcesFields {
+	Title: string
+	Type: string | null
+	Short_Description: string | null
+	URL: string | null
+	Language: string | null
+}
 
 export interface BlogPostFields {
 	Title: string

--- a/webapp/types/apiTypes.ts
+++ b/webapp/types/apiTypes.ts
@@ -81,7 +81,7 @@ export type RessourcesRecord = Record<RessourcesFields>
 export interface RessourcesFields {
 	Title: string
 	Type: string | null
-	Short_Description: string | null
+	'Short Description': string | null
 	URL: string | null
 	Language: string | null
 }


### PR DESCRIPTION
## Summary

Replaces mock resources on the Resources page with data from the NocoDB **Ressources** table: `getTableIdByName`, locale filter on `Language`, sort by `nc_order`.

## Changes

- Types: `Ressources` in `TableTitle`; `RessourcesRecord` / `RessourcesFields` aligned with the Data API.
- Fetcher: `webapp/lib/fetchRessources.ts`.
- Page: async server component; no `notFound()` when the list is empty.
- UI: `ResourceCard` type registry + external links.

## Fix included

Description field uses NocoDB column title `Short Description` (not Postgres `Short_Description`) so descriptions render from the API.

Closes #53